### PR TITLE
Improve "Files" confirmation

### DIFF
--- a/config/config-sample.ts
+++ b/config/config-sample.ts
@@ -23,6 +23,7 @@ const config = {
     from: 'from',
     language: 'Language',
     msg_sent: 'Message sent to user',
+    file_sent: 'File sent to user',
     usr_with_ticket: 'User with ticket',
     banned: 'banned',
     replyPrivate: 'Reply in private',

--- a/src/files.ts
+++ b/src/files.ts
@@ -170,7 +170,7 @@ function fileHandler(type, bot, ctx) {
       }
       // Confirmation message
       bot.telegram.sendMessage(
-        ctx.from.id,
+        ctx.chat.id,
         config.language.msg_sent);
     });
   });

--- a/src/files.ts
+++ b/src/files.ts
@@ -169,9 +169,12 @@ function fileHandler(type, bot, ctx) {
           break;
       }
       // Confirmation message
+      const name = replyText.match(new RegExp(
+          config.language.from + ' ' + '(.*)' + ' ' +
+          config.language.language));
       bot.telegram.sendMessage(
         ctx.chat.id,
-        config.language.msg_sent);
+        `${config.language.msg_sent} ${name[1]}`);
     });
   });
 }

--- a/src/files.ts
+++ b/src/files.ts
@@ -169,12 +169,17 @@ function fileHandler(type, bot, ctx) {
           break;
       }
       // Confirmation message
-      const name = replyText.match(new RegExp(
-          config.language.from + ' ' + '(.*)' + ' ' +
-          config.language.language));
+      let message = config.language.contactMessage;
+      // if admin
+      if(ctx.session.admin && userInfo === undefined) {
+        const name = replyText.match(new RegExp(
+            config.language.from + ' ' + '(.*)' + ' ' +
+            config.language.language));
+        message = `${config.language.msg_sent} ${name[1]}`;
+      }
       bot.telegram.sendMessage(
         ctx.chat.id,
-        `${config.language.msg_sent} ${name[1]}`);
+        message);
     });
   });
 }

--- a/src/files.ts
+++ b/src/files.ts
@@ -175,7 +175,7 @@ function fileHandler(type, bot, ctx) {
         const name = replyText.match(new RegExp(
             config.language.from + ' ' + '(.*)' + ' ' +
             config.language.language));
-        message = `${config.language.msg_sent} ${name[1]}`;
+        message = `${config.language.file_sent} ${name[1]}`;
       }
       bot.telegram.sendMessage(
         ctx.chat.id,


### PR DESCRIPTION
Staff: Confirmation wasn't sent in the chat and didn't include the recipient's name
User: "Staff message" replaced by "config.language.contactMessage" 

Doubts, maybe it would be worth adding a dedicated message to be sent to users sending files?