### PR TITLE
Fix: spam_time, '429: Too Many Requests'. Feat: autoreply_confirmation, clean_replies, pass_start.

### DIFF
--- a/config/config-sample.yaml
+++ b/config/config-sample.yaml
@@ -14,6 +14,7 @@ anonymous_tickets: true # Include userid in tickets or not
 anonymous_replies: true # Include staff member name in response
 show_auto_replied: false # Send auto replied msgs to staff chat
 show_user_ticket: false # Show ticket id to user
+autoreply_confirmation: true # Reply with language.confirmationMessage on each incoming message
 
 signal_enabled: false # Enable/disable signal
 signal_number: '+12345689' # Your signal number / account
@@ -37,7 +38,7 @@ language:
     /clear - *Staff* Closes all tickets 
     /ban - *Staff* Ban a user from the chat 
     /unban - *Staff* Unban a user"
-  contactMessage: "Thank you for contacting us. We will answer as soon as possible. "
+  confirmationMessage: "Thank you for contacting us. We will answer as soon as possible. "
   blockedSpam: 'You sent quite a number of questions in the last while. Please calm down and wait until staff reviews them.'
   ticket: 'Ticket'
   closed: 'closed'

--- a/config/config-sample.yaml
+++ b/config/config-sample.yaml
@@ -15,6 +15,7 @@ anonymous_replies: true # Include staff member name in response
 show_auto_replied: false # Send auto replied msgs to staff chat
 show_user_ticket: false # Show ticket id to user
 autoreply_confirmation: true # Reply with language.confirmationMessage on each incoming message
+clean_replies: false # Remove footer and header from response
 
 signal_enabled: false # Enable/disable signal
 signal_number: '+12345689' # Your signal number / account

--- a/config/config-sample.yaml
+++ b/config/config-sample.yaml
@@ -2,7 +2,7 @@
 bot_token: 'YOUR_BOT_TOKEN' # support bot token
 staffchat_id: 'SUPERGROUP_CHAT_ID' # eg. -123456789
 owner_id: 'YOUR_TELEGRAM_ID'
-spam_time: 5 * 60 * 1000 # time (in MS) in which user may send 5 messages
+spam_time: 300000 # time (in MS) in which user may send 5 messages
 spam_cant_msg: 5
 
 parse_mode: 'MarkdownV2' # Experimental. Do not change unless you know what you are doing. Options: Markdown/MarkdownV2/HTML

--- a/config/config-sample.yaml
+++ b/config/config-sample.yaml
@@ -16,6 +16,7 @@ show_auto_replied: false # Send auto replied msgs to staff chat
 show_user_ticket: false # Show ticket id to user
 autoreply_confirmation: true # Reply with language.confirmationMessage on each incoming message
 clean_replies: false # Remove footer and header from response
+pass_start: false # Pass /start command to support directly
 
 signal_enabled: false # Enable/disable signal
 signal_number: '+12345689' # Your signal number / account

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,22 @@
 {
     "name": "telegram-support-bot",
-    "version": "3.2.0",
+    "version": "4.0.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "telegram-support-bot",
-            "version": "3.2.0",
+            "version": "4.0.0",
             "license": "GPL-3.0",
             "dependencies": {
+                "@grammyjs/transformer-throttler": "^1.2.1",
                 "better-sqlite3": "^7.5.3",
                 "chalk": "^5.0.1",
                 "debug": "^4.3.4",
                 "express": "^4.18.1",
                 "express-rate-limit": "^6.4.0",
                 "grammy": "^1.9.0",
-                "node-fetch": "^3.2.6",
+                "node-fetch": ">=3.2.10",
                 "node-gyp": "^9.0.0",
                 "sandwich-stream": "^2.0.2",
                 "socket.io": "^4.5.1",
@@ -104,6 +105,20 @@
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
             "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw=="
+        },
+        "node_modules/@grammyjs/transformer-throttler": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@grammyjs/transformer-throttler/-/transformer-throttler-1.2.1.tgz",
+            "integrity": "sha512-CpWB0F3rJdUiKsq7826QhQsxbZi4wqfz1ccKX+fr+AOC+o8K7ZvS+wqX0suSu1QCsyUq2MDpNiKhyL2ZOJUS4w==",
+            "dependencies": {
+                "bottleneck": "^2.0.0"
+            },
+            "engines": {
+                "node": "^12.20.0 || >=14.13.1"
+            },
+            "peerDependencies": {
+                "grammy": "^1.0.0"
+            }
         },
         "node_modules/@grammyjs/types": {
             "version": "2.8.1",
@@ -858,6 +873,11 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
             "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+        },
+        "node_modules/bottleneck": {
+            "version": "2.19.5",
+            "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+            "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw=="
         },
         "node_modules/brace-expansion": {
             "version": "1.1.11",
@@ -3788,9 +3808,9 @@
             }
         },
         "node_modules/node-fetch": {
-            "version": "3.2.6",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.6.tgz",
-            "integrity": "sha512-LAy/HZnLADOVkVPubaxHDft29booGglPFDr2Hw0J1AercRh01UiVFm++KMDnJeH9sHgNB4hsXPii7Sgym/sTbw==",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.0.tgz",
+            "integrity": "sha512-BKwRP/O0UvoMKp7GNdwPlObhYGB5DQqwhEDQlNKuoqwVYSxkSZCSbHjnFFmUEtwSKRPU4kNK8PbDYYitwaE3QA==",
             "dependencies": {
                 "data-uri-to-buffer": "^4.0.0",
                 "fetch-blob": "^3.1.4",
@@ -5637,6 +5657,14 @@
             "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
             "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw=="
         },
+        "@grammyjs/transformer-throttler": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@grammyjs/transformer-throttler/-/transformer-throttler-1.2.1.tgz",
+            "integrity": "sha512-CpWB0F3rJdUiKsq7826QhQsxbZi4wqfz1ccKX+fr+AOC+o8K7ZvS+wqX0suSu1QCsyUq2MDpNiKhyL2ZOJUS4w==",
+            "requires": {
+                "bottleneck": "^2.0.0"
+            }
+        },
         "@grammyjs/types": {
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/@grammyjs/types/-/types-2.8.1.tgz",
@@ -6179,6 +6207,11 @@
                     "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
                 }
             }
+        },
+        "bottleneck": {
+            "version": "2.19.5",
+            "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+            "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw=="
         },
         "brace-expansion": {
             "version": "1.1.11",
@@ -8301,9 +8334,9 @@
             "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
         },
         "node-fetch": {
-            "version": "3.2.6",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.6.tgz",
-            "integrity": "sha512-LAy/HZnLADOVkVPubaxHDft29booGglPFDr2Hw0J1AercRh01UiVFm++KMDnJeH9sHgNB4hsXPii7Sgym/sTbw==",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.0.tgz",
+            "integrity": "sha512-BKwRP/O0UvoMKp7GNdwPlObhYGB5DQqwhEDQlNKuoqwVYSxkSZCSbHjnFFmUEtwSKRPU4kNK8PbDYYitwaE3QA==",
             "requires": {
                 "data-uri-to-buffer": "^4.0.0",
                 "fetch-blob": "^3.1.4",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
         "node": ">=6.2.0"
     },
     "dependencies": {
+        "@grammyjs/transformer-throttler": "^1.2.1",
         "better-sqlite3": "^7.5.3",
         "chalk": "^5.0.1",
         "debug": "^4.3.4",

--- a/src/addons/telegram.ts
+++ b/src/addons/telegram.ts
@@ -4,6 +4,7 @@
 
 import {Bot, Context as GrammyContext, SessionFlavor, session} from 'grammy';
 import {Context, SessionData} from '../interfaces';
+import { apiThrottler } from "@grammyjs/transformer-throttler";
 
 /**
  * Telegram Ticketing System - Telegram Implementation with GrammY
@@ -18,6 +19,8 @@ class TelegramAddon {
   constructor(token: string) {
     type BotContext = GrammyContext & SessionFlavor<SessionData>;
     this.bot = new Bot<BotContext>(token);
+    const throttler = apiThrottler();
+    this.bot.api.config.use(throttler);
     this.bot.init().then(() => {
       this.botInfo = this.bot.botInfo;
     });

--- a/src/files.ts
+++ b/src/files.ts
@@ -217,7 +217,7 @@ function fileHandler(type: string, bot: TelegramAddon, ctx: Context) {
           }
           // Confirmation message
           let message =
-          cache.config.language.contactMessage +
+          cache.config.language.confirmationMessage +
           (cache.config.show_user_ticket ?
             cache.config.language.yourTicketId +
             ' #T' +

--- a/src/files.ts
+++ b/src/files.ts
@@ -216,6 +216,9 @@ function fileHandler(type: string, bot: TelegramAddon, ctx: Context) {
               break;
           }
           // Confirmation message
+          if (!cache.config.autoreply_confirmation) {
+            return;
+          }
           let message =
           cache.config.language.confirmationMessage +
           (cache.config.show_user_ticket ?

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ function createBot() {
   }
   cache.config.autoreply_confirmation = cache.config.autoreply_confirmation === undefined ? true : cache.config.autoreply_confirmation
   cache.config.language.confirmationMessage = cache.config.language.confirmationMessage || cache.config.language.contactMessage // left for backward compatibility
+  cache.config.clean_replies = cache.config.clean_replies === undefined ? false : cache.config.clean_replies // left for backward compatibility
 
   return defaultBot;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,8 @@ function createBot() {
     }
     defaultBot = new TelegramAddon(cache.config.bot_token);
   }
+  cache.config.autoreply_confirmation = cache.config.autoreply_confirmation === undefined ? true : cache.config.autoreply_confirmation
+  cache.config.language.confirmationMessage = cache.config.language.confirmationMessage || cache.config.language.contactMessage // left for backward compatibility
 
   return defaultBot;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,8 @@ function createBot() {
   cache.config.autoreply_confirmation = cache.config.autoreply_confirmation === undefined ? true : cache.config.autoreply_confirmation
   cache.config.language.confirmationMessage = cache.config.language.confirmationMessage || cache.config.language.contactMessage // left for backward compatibility
   cache.config.clean_replies = cache.config.clean_replies === undefined ? false : cache.config.clean_replies // left for backward compatibility
+  cache.config.pass_start = cache.config.pass_start === undefined ? false : cache.config.pass_start // left for backward compatibility
+
 
   return defaultBot;
 }
@@ -92,22 +94,24 @@ function main(bot: TelegramAddon = defaultBot, logs = true) {
   bot.command('reopen', (ctx: Context) => commands.reopenCommand(ctx));
   bot.command('unban', (ctx: Context) => commands.unbanCommand(ctx));
   bot.command('clear', (ctx: Context) => commands.clearCommand(ctx));
-  bot.command('start', (ctx: Context) => {
-    if (ctx.chat.type == 'private') {
-      middleware.reply(ctx, cache.config.language.startCommandText);
-      if (cache.config.categories && cache.config.categories.length > 0) {
-        setTimeout(
-            () =>
-              middleware.reply(
-                  ctx,
-                  cache.config.language.services,
-                  inline.replyKeyboard(keys),
-              ),
-            500,
-        );
-      }
-    } else middleware.reply(ctx, cache.config.language.prvChatOnly);
-  });
+  if (cache.config.pass_start == false) {
+    bot.command('start', (ctx: Context) => {
+      if (ctx.chat.type == 'private') {
+        middleware.reply(ctx, cache.config.language.startCommandText);
+        if (cache.config.categories && cache.config.categories.length > 0) {
+          setTimeout(
+              () =>
+                middleware.reply(
+                    ctx,
+                    cache.config.language.services,
+                    inline.replyKeyboard(keys),
+                ),
+              500,
+          );
+        }
+      } else middleware.reply(ctx, cache.config.language.prvChatOnly);
+    });
+  }
   bot.command('id', (ctx: Context) =>
     middleware.reply(ctx, `User ID: ${ctx.from.id}\nGroup ID: ${ctx.chat.id}`, {
       parse_mode: cache.config.parse_mode,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -104,6 +104,7 @@ interface Config {
   autoreply_confirmation: boolean;
   autoreply: Autoreply[];
   clean_replies: boolean;
+  pass_start: boolean;
   categories: Category[];
 }
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -26,7 +26,8 @@ interface Language {
   startCommandText: string;
   faqCommandText: string;
   helpCommandText: string;
-  contactMessage: string;
+  confirmationMessage: string;
+  contactMessage: string; // left for backward compatibility
   blockedSpam: string;
   ticket: string;
   closed: string;
@@ -100,6 +101,7 @@ interface Config {
   dev_mode: boolean;
   show_user_ticket: boolean;
   language: Language;
+  autoreply_confirmation: boolean;
   autoreply: Autoreply[];
   categories: Category[];
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -103,6 +103,7 @@ interface Config {
   language: Language;
   autoreply_confirmation: boolean;
   autoreply: Autoreply[];
+  clean_replies: boolean;
   categories: Category[];
 }
 

--- a/src/staff.ts
+++ b/src/staff.ts
@@ -14,6 +14,9 @@ function ticketMsg(
     message: { text: any; from: { first_name: any } },
 ) {
   const esc: any = middleware.strictEscape;
+  if (cache.config.clean_replies) {
+    return esc(message.text)
+  }
   if (cache.config.anonymous_replies) {
     return (
       `${cache.config.language.dear} ` +

--- a/src/users.ts
+++ b/src/users.ts
@@ -46,7 +46,7 @@ function autoReply(ctx: Context) {
   for (const i in strings) {
     if (ctx.message.text.toString().indexOf(strings[i]['question']) > -1) {
       // Define message
-      const msg =
+      const msg = cache.config.clean_replies ? strings[i]['answer'] :
         `${cache.config.language.dear} ` +
         `${ctx.message.from.first_name},\n\n` +
         `${strings[i]['answer']}\n\n` +

--- a/src/users.ts
+++ b/src/users.ts
@@ -91,10 +91,10 @@ function chat(ctx: Context, chat: { id: string }) {
         chat.id,
         ctx.session.groupCategory,
         function(ticket: { id: string }) {
-          if (!isAutoReply) {
+          if (!isAutoReply && cache.config.autoreply_confirmation) {
             middleware.msg(
                 chat.id,
-                cache.config.language.contactMessage + '\n' +
+                cache.config.language.confirmationMessage + '\n' +
               (cache.config.show_user_ticket ?
                 cache.config.language.ticket +
                   ' #T' +

--- a/test/test.ts
+++ b/test/test.ts
@@ -21,7 +21,7 @@ describe('Messages', function() {
       botAssert.assertMsgWildcard(
           'Hello, this is some test!',
           expected,
-          lang.contactMessage,
+          lang.confirmationMessage,
       );
     });
   });


### PR DESCRIPTION
- Antispam is broken due to math operations is not allowed in YAML (when migrated from config.ts). Can't be fixed for backward compatibility because `eval('5*60*1000')` is not supported in TS. At least config-sample.yaml is fixed.
- '429: Too Many Requests' Telegram error is not handled. Could be reproduced by sending many user messages exceeding bot limits. Fixed with native grammY plugin.
- config.clean_replies allows to send clean messages from support with no footer nor header.
- config.autoreply_confirmation disables autoreplys with 'message received' confirmation
- config.pass_start passes first message from the client to suport team directly