### PR TITLE
Using 'msg' and 'group_id' at the same time. Some /clear and /close fixes.

### DIFF
--- a/config/config-sample.yaml
+++ b/config/config-sample.yaml
@@ -108,6 +108,7 @@ autoreply:
 #  - name: "Admin Chat"
 #    group_id: "-12345678910"
 #  - name: "Other issues"
+#    tag: "#other"
 #    msg: "Please specify your order number and describe the problem in as much detail as possible"
 #    group_id: "-12345678910"
 #  - name: "Contact"

--- a/config/config-sample.yaml
+++ b/config/config-sample.yaml
@@ -107,6 +107,9 @@ autoreply:
 #    group_id: "-12345678910"
 #  - name: "Admin Chat"
 #    group_id: "-12345678910"
+#  - name: "Other issues"
+#    msg: "Please specify your order number and describe the problem in as much detail as possible"
+#    group_id: "-12345678910"
 #  - name: "Contact"
 #    msg: "Check out our Website"
 

--- a/src/addons/telegram.ts
+++ b/src/addons/telegram.ts
@@ -89,6 +89,7 @@ class TelegramAddon {
         modeData: {} as any,
         mode: null,
         groupCategory: null,
+        groupTag: '',
         group: '',
         groupAdmin: {} as any,
         getSessionKey: (ctx: Context) => {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -105,7 +105,7 @@ function closeCommand(ctx: Context) {
   if (cache.config.categories) {
     cache.config.categories.forEach((element: any, index: number) => {
       // No subgroup
-      if (cache.config.categories[index].subgroups.length > 0) {
+      if (cache.config.categories[index].subgroups == undefined) {
         if (cache.config.categories[index].group_id == ctx.chat.id) {
           groups.push(cache.config.categories[index].name);
         }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -108,7 +108,10 @@ function closeCommand(ctx: Context) {
   if (cache.config.categories) {
     cache.config.categories.forEach((element: any, index: number) => {
       // No subgroup
-      if (cache.config.categories[index].subgroups == undefined) {
+      if (
+        cache.config.categories[index].subgroups == undefined ||
+        cache.config.categories[index].subgroups.length == 0
+        ) {
         if (cache.config.categories[index].group_id == ctx.chat.id) {
           groups.push(cache.config.categories[index].name);
         }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -26,6 +26,9 @@ function helpCommand(ctx: Context) {
 function clearCommand(ctx: Context) {
   if (!ctx.session.admin) return;
   db.closeAll();
+  cache.ticketIDs.length = 0;
+  cache.ticketStatus.length = 0;
+  cache.ticketSent.length = 0;
   middleware.reply(
     ctx,
     'All tickets closed.',
@@ -156,21 +159,23 @@ function closeCommand(ctx: Context) {
     }
     middleware.reply(
       ctx,
-      `
-    ${cache.config.language.ticket} 
-    #T${ticketId.toString().padStart(6, '0')} ` +
+      `${cache.config.language.ticket} ` +
+      `#T${ticketId.toString().padStart(6, '0')} ` +
       `${cache.config.language.closed}`,
       // eslint-disable-next-line new-cap
       { parse_mode: cache.config.parse_mode }, /* .notifications(false) */
     );
     middleware.msg(
       userid,
-      `${cache.config.language.ticket} 
-        #T${ticketId.toString().padStart(6, '0')} ` +
+      `${cache.config.language.ticket} ` +
+      `#T${ticketId.toString().padStart(6, '0')} ` +
       `${cache.config.language.closed}\n\n
       ${cache.config.language.ticketClosed}`,
       { parse_mode: cache.config.parse_mode }, /* .notifications(false) */
     );
+    delete cache.ticketIDs[userid];
+    delete cache.ticketStatus[userid];
+    delete cache.ticketSent[userid];
   }, groups);
 }
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -47,7 +47,7 @@ function openCommand(ctx: Context) {
   ) {
     cache.config.categories.forEach((element: any, index: number) => {
       // No subgroup
-      if (element.subgroups.length == 0) {
+      if (element.subgroups == undefined) {
         if (element.group_id == ctx.chat.id) {
           groups.push(element.name);
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -112,7 +112,7 @@ function main(bot: TelegramAddon = defaultBot, logs = true) {
               cache.config.categories[i].subgroups[j].name
             )
               .replace(/[\[\]\:\ "]/g, '')
-              .substr(0, 63);
+              .substring(0, 63);
             if (subcategories.indexOf(id) == -1) {
               subcategories.push(id);
               if (bot.botInfo != null) {

--- a/src/inline.ts
+++ b/src/inline.ts
@@ -66,9 +66,9 @@ function initInline(bot: TelegramAddon) {
               `*${cache.config.categories[i].name}*`,
               removeKeyboard(),
             );
-            ctx.session.group = cache.config.categories[i].group_id;
-            ctx.session.groupCategory = cache.config.categories[i].name;
           }
+          ctx.session.group = cache.config.categories[i].group_id;
+          ctx.session.groupCategory = cache.config.categories[i].name;
         });
         // Create subcategory button events
         bot.hears(cache.config.categories[i].name, (ctx: Context) => {
@@ -85,9 +85,9 @@ function initInline(bot: TelegramAddon) {
               `*${cache.config.categories[i].name}*`,
               removeKeyboard(),
             );
-            ctx.session.group = cache.config.categories[i].group_id;
-            ctx.session.groupCategory = cache.config.categories[i].name;
           }
+          ctx.session.group = cache.config.categories[i].group_id;
+          ctx.session.groupCategory = cache.config.categories[i].name;
         });
         continue;
       }

--- a/src/inline.ts
+++ b/src/inline.ts
@@ -68,6 +68,7 @@ function initInline(bot: TelegramAddon) {
             );
           }
           ctx.session.group = cache.config.categories[i].group_id;
+          ctx.session.groupTag = cache.config.categories[i].tag || '';
           ctx.session.groupCategory = cache.config.categories[i].name;
         });
         // Create subcategory button events
@@ -87,6 +88,7 @@ function initInline(bot: TelegramAddon) {
             );
           }
           ctx.session.group = cache.config.categories[i].group_id;
+          ctx.session.groupTag = cache.config.categories[i].tag || '';
           ctx.session.groupCategory = cache.config.categories[i].name;
         });
         continue;

--- a/src/inline.ts
+++ b/src/inline.ts
@@ -51,7 +51,7 @@ function initInline(bot: TelegramAddon) {
           '/start ' +
           cache.config.categories[i].name
             .replace(/[\[\]\:\ "]/g, '')
-            .substr(0, 63);
+            .substring(0, 63);
         bot.hears(startStr, (ctx: Context) => {
           ctx.session.mode = '';
           ctx.session.modeData = {} as ModeData;
@@ -107,7 +107,7 @@ function initInline(bot: TelegramAddon) {
             '/start ' +
             JSON.stringify(categoryFullId)
               .replace(/[\[\]\:\ "]/g, '')
-              .substr(0, 63);
+              .substring(0, 63);
           bot.hears(startStr, (ctx: Context) => {
             ctx.session.mode = '';
             ctx.session.modeData = {} as ModeData;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -12,6 +12,7 @@ interface SessionData {
   mode: string | null;
   modeData: ModeData;
   groupCategory: string | null;
+  groupTag: string;
   group: string;
   groupAdmin: any;
   getSessionKey: Function;
@@ -72,6 +73,7 @@ interface Language {
 interface Category {
   name: string;
   msg: string;
+  tag: string;
   group_id: string;
   subgroups: {
     name: string;

--- a/src/users.ts
+++ b/src/users.ts
@@ -16,6 +16,7 @@ function ticketMsg(
     from: { first_name: string | any[]; language_code: any };
     text: string | any[];
   },
+  tag: string,
   anon = true,
   autoReplyInfo: any,
 ) {
@@ -29,7 +30,7 @@ function ticketMsg(
     `#T${ticket.toString().padStart(6, '0')} ${cache.config.language.from} ` +
     `[${esc(message.from.first_name)}](${link})` +
     ` ${cache.config.language.language}: ` +
-    `${message.from.language_code}\n\n` +
+    `${message.from.language_code} ${tag}\n\n` +
     `${esc(message.text)}\n\n` +
     (autoReplyInfo ? `_${autoReplyInfo}_` : '')
   );
@@ -109,6 +110,7 @@ function chat(ctx: Context, chat: { id: string }) {
           ticketMsg(
             ticket.id,
             ctx.message,
+            ctx.session.groupTag,
             cache.config.anonymous_tickets,
             autoReplyInfo,
           ),
@@ -126,6 +128,7 @@ function chat(ctx: Context, chat: { id: string }) {
             ticketMsg(
               ticket.id,
               ctx.message,
+              ctx.session.groupTag,
               cache.config.anonymous_tickets,
               autoReplyInfo,
             ),
@@ -175,6 +178,7 @@ function chat(ctx: Context, chat: { id: string }) {
           ticketMsg(
             ticket.id,
             ctx.message,
+            ctx.session.groupTag,
             cache.config.anonymous_tickets,
             autoReplyInfo,
           ),
@@ -189,6 +193,7 @@ function chat(ctx: Context, chat: { id: string }) {
             ticketMsg(
               ticket.id,
               ctx.message,
+              ctx.session.groupTag,
               cache.config.anonymous_tickets,
               autoReplyInfo,
             ),
@@ -213,6 +218,7 @@ function chat(ctx: Context, chat: { id: string }) {
         ticketMsg(
           ticket.id,
           ctx.message,
+          ctx.session.groupTag,
           cache.config.anonymous_tickets,
           autoReplyInfo,
         ),

--- a/src/users.ts
+++ b/src/users.ts
@@ -180,7 +180,10 @@ function chat(ctx: Context, chat: { id: string }) {
           ),
           { parse_mode: cache.config.parse_mode },
         );
-        if (ctx.session.group !== '') {
+        if (
+          ctx.session.group !== '' &&
+          ctx.session.group != cache.config.staffchat_id
+        ) {
           middleware.msg(
             ctx.session.group,
             ticketMsg(


### PR DESCRIPTION
[Remove tickets from cache on /clear and /close](https://github.com/bostrot/telegram-support-bot/commit/9719bbb9307d4503af3f3116e2fbf9ffb34e0e6b). Otherwise, the user will not receive a notification about sending a message if the previous ticket was closed. It may also be related to the [issue #121](https://github.com/bostrot/telegram-support-bot/issues/121).

[Allow to use 'msg' and 'group_id' at the same time](https://github.com/bostrot/telegram-support-bot/commit/0491e5578488f39ed5b3392a69788ef07164f255). It is convenient if additional information is always needed to answer a question. Also, it looks like a solution for [issue #99](https://github.com/bostrot/telegram-support-bot/issues/99).