### PR TITLE
Fix: Escape user name in staff msg sent

### DIFF
--- a/src/staff.ts
+++ b/src/staff.ts
@@ -168,11 +168,11 @@ function chat(ctx: Context) {
             { parse_mode: cache.config.parse_mode },
           );
         }
-
+        const esc: any = middleware.strictEscape;
         // To staff msg sent
         middleware.msg(
           ctx.chat.id,
-          `${cache.config.language.msg_sent} ${name[1]}`,
+          `${cache.config.language.msg_sent} ${esc(name[1])}`,
           // eslint-disable-next-line new-cap
           { parse_mode: cache.config.parse_mode }, /* .notifications(false) */
         );


### PR DESCRIPTION
Escape user name in message that is sent to staff channel