### PR TITLE
Fix broken web chat - cannot read properties of undefined

### DIFF
--- a/src/addons/fakectx.ts
+++ b/src/addons/fakectx.ts
@@ -36,7 +36,11 @@ const fakectx: Context = {
     username: 'webuser',
     type: 'private',
   },
-  session: {} as SessionData,
+  session: {
+    group: '',
+    groupTag: '',
+    groupCategory: null
+  } as SessionData,
   callbackQuery: {
     data: '',
     from: {


### PR DESCRIPTION
Current web chat broken and can't process income user messages due error:
```
TypeError: Cannot read properties of undefined (reading 'toString')
```

That's PR fix the problem with wrong/undefined group settings for web messages. Now it uses same default values as direct tg messages. New version works fine with it (tg and web messages).

Original error stack:
```
=== UNHANDLED ERROR ===
[ERROR] 14:00:04 TypeError: Cannot read properties of undefined (reading 'toString')
...
Error:  TypeError: Cannot read properties of undefined (reading 'toString')
    at Object.msg (C:\WORK\xxx\telegram-support-bot\src\middleware.ts:67:10)
    at C:\WORK\xxx\telegram-support-bot\src\users.ts:126:22
    at Object.getOpen (C:\WORK\xxx\telegram-support-bot\src\db.ts:42:3)
    at Object.chat (C:\WORK\xxx\telegram-support-bot\src\users.ts:91:8)
    at C:\WORK\xxx\telegram-support-bot\src\text.ts:51:17
    at Object.getOpen (C:\WORK\xxx\telegram-support-bot\src\db.ts:42:3)
    at ticketHandler (C:\WORK\xxx\telegram-support-bot\src\text.ts:44:8)
    at Socket.<anonymous> (C:\WORK\xxx\telegram-support-bot\src\addons\web.ts:56:26)
    at Socket.emit (node:events:513:28)
    at Socket.emitUntyped (C:\WORK\xxx\telegram-support-bot\node_modules\socket.io\dist\typed-events.js:69:22)
```

Closes #141