### PR TITLE
Fix uncompatible config path for Windows systems (can't run docker compose)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,6 @@ services:
     build: .
     restart: unless-stopped
     volumes:
-      - ${PWD}/config:/bot/config
+      - ./config:/bot/config
     ports:
       - "8080:8080"


### PR DESCRIPTION
Windows systems uses `cd` command instead linux's `pwd`. So current docker-compose file uncompatible with Docker Desktop software on Windows systems (see #150).

That PR fix the problem - now it uses relative paths.

Closes #150