### PR TITLE
Fix MongoDB connection for Docker environments

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -1,7 +1,7 @@
 import mongoose from 'mongoose';
 import cache from './cache';
 
-const MONGO_URI = cache.config.mongodb_uri || 'mongodb://localhost:27017/support';
+const MONGO_URI = cache.config.mongodb_uri || process.env.MONGO_URI || 'mongodb://localhost:27017/support';
 const botTokenSuffix = cache.config.bot_token.slice(-5);
 const collectionName = `bot_${cache.config.owner_id}_${botTokenSuffix}`;
 


### PR DESCRIPTION
### What was fixed

The bot previously hardcoded `mongodb://localhost:27017/support`, which fails in Docker environments.

This PR adds support for reading the MongoDB URI from the `MONGO_URI` environment variable, allowing proper inter-container communication with the MongoDB service.

### Changes

- `src/db.ts`: now uses `process.env.MONGO_URI` as a fallback if not defined in the config

### Example usage in `docker-compose.yml`:

```yaml
environment:
  - MONGO_URI=mongodb://mongodb:27017/support