### PR TITLE
Fix: await ticket creation so the first message reaches the staff chat

### DIFF
--- a/src/text.ts
+++ b/src/text.ts
@@ -67,9 +67,15 @@ export async function ticketHandler(bot: Addon, ctx: Context): Promise<ISupporte
   const { chat, message, session, messenger } = ctx;
   // For private chats, check for an existing ticket; otherwise, create one.
   if (chat.type === 'private') {
-    const ticket = await db.getTicketByUserId(message.from.id, session.groupCategory)
+    let ticket = await db.getTicketByUserId(message.from.id, session.groupCategory)
     if (!ticket) {
-      db.add(message.from.id, 'open', session.groupCategory, messenger);
+      // db.add must be awaited: users.chat() reads the ticket back from the DB
+      // immediately, so firing this off unawaited made every first message from
+      // a new user crash in processTicket() with "Cannot read properties of null
+      // (reading 'ticketId')" - and never reach the staff chat.
+      await db.add(message.from.id, 'open', session.groupCategory, messenger);
+      // findOneAndReplace() returns the pre-image (null on insert), so re-read.
+      ticket = await db.getTicketByUserId(message.from.id, session.groupCategory);
     }
     users.chat(ctx, message.chat);
     return ticket;

--- a/src/users.ts
+++ b/src/users.ts
@@ -188,7 +188,11 @@ async function chat(ctx: Context, chat: { id: string }) {
   // If no ticket has been sent yet, fetch from DB and set up spam timer
   if (cache.ticketSent[cache.userId] === undefined) {
     const ticket = await db.getTicketByUserId(chat.id, ctx.session.groupCategory);
-    processTicket(ticket, ctx, chat.id, autoReplyInfo);
+    if (!ticket) {
+      log.error(`No ticket found for user ${cache.userId}, dropping message.`);
+      return;
+    }
+    await processTicket(ticket, ctx, chat.id, autoReplyInfo);
 
     // Prevent multiple notifications for a period defined by spam_time
     setTimeout(() => {
@@ -198,6 +202,10 @@ async function chat(ctx: Context, chat: { id: string }) {
   } else if (cache.ticketSent[cache.userId] < config.spam_cant_msg) {
     cache.ticketSent[cache.userId]++;
     const ticket = await db.getTicketByUserId(cache.userId, ctx.session.groupCategory);
+    if (!ticket) {
+      log.error(`No ticket found for user ${cache.userId}, dropping message.`);
+      return;
+    }
     sendMessage(
       config.staffchat_id,
       config.staffchat_type,
@@ -225,13 +233,15 @@ async function chat(ctx: Context, chat: { id: string }) {
 
   // Log the ticket message for debugging
   const ticket = await db.getTicketByUserId(cache.userId, ctx.session.groupCategory)
-  log.info(
-    formatMessageAsTicket(
-      ticket.ticketId,
-      ctx,
-      autoReplyInfo,
-    ),
-  );
+  if (ticket) {
+    log.info(
+      formatMessageAsTicket(
+        ticket.ticketId,
+        ctx,
+        autoReplyInfo,
+      ),
+    );
+  }
 }
 
 export { chat };


### PR DESCRIPTION
## The bug

The **first message from a new user never reaches the staff chat**. The user gets the confirmation message, a ticket row appears in MongoDB, and the staff group stays silent. The second message from the same user works, which makes this easy to miss.

Log from a fresh deployment (v5.0.0, MongoDB 8.0):

```
=== UNHANDLED REJECTION ===
TypeError: Cannot read properties of null (reading 'ticketId')
    at processTicket (/bot/build/users.js:128:57)
    at Object.chat (/bot/build/users.js:184:9)
```

## Cause

`ticketHandler()` in `src/text.ts` creates the ticket without awaiting it, and `users.chat()` re-reads that same ticket from MongoDB immediately after:

```ts
const ticket = await db.getTicketByUserId(message.from.id, session.groupCategory)
if (!ticket) {
  db.add(message.from.id, 'open', session.groupCategory, messenger);  // not awaited
}
users.chat(ctx, message.chat);  // re-reads the ticket -> loses the race, gets null
```

`processTicket()` then dereferences `ticket.ticketId` and throws before `sendMessage()` to the staff chat is ever reached.

## Fix

- `text.ts`: `await db.add()` and re-read the ticket. `findOneAndReplace()` returns the pre-image (`null` on insert), so its return value cannot be used directly.
- `users.ts`: `await processTicket()` so failures surface instead of becoming unhandled rejections, and guard the three ticket reads against `null` so a missing ticket logs an error instead of throwing.

## Verification

Reproduced on a clean deployment: with an empty tickets collection, the first message from a new user was lost every time. After the patch the same first message creates ticket `#T000001` and arrives in the staff group; replying to it reaches the user and auto-closes the ticket.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YAMqiW6TfJVcywxpBQjdH3