### PR TITLE
v5: team collaboration, analytics, Discord/Slack addons, file logger and Docker fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,92 @@
+# AGENTS.md — telegram-support-bot
+
+## Quick start
+
+```bash
+cp config/config-sample.yaml config/config.yaml   # create config (edit bot_token, staffchat_id, owner_id)
+npm install
+docker compose up -d mongodb                       # MongoDB is required at runtime
+npm run dev                                        # ts-node-dev hot-reload loop
+```
+
+## Commands
+
+| Command | Description |
+|---|---|
+| `npm run dev` | Development server via `ts-node-dev` (watch + restart) |
+| `npm run build` or `npm run tsc` | Compile TypeScript → `build/` |
+| `npm run prod` | Run compiled JS (`node ./build/index.js`) — requires prior `npm run build` |
+| `npm test` | Run Jest suite (always uses `--detectOpenHandles --forceExit --runInBand`) |
+
+There is **no** lint or format script in `package.json`. ESLint config exists at `.eslintrc.yml` but must be invoked manually: `npx eslint src/`.
+
+## Running the bot
+
+### 1. Direct (npm)
+```bash
+cp config/config-sample.yaml config/config.yaml   # edit bot_token, staffchat_id, owner_id
+npm install
+docker compose up -d mongodb                       # MongoDB is required at runtime
+npm run build && npm run prod                      # compile and start
+# or for development with hot-reload:
+npm run dev
+```
+
+### 2. Docker Compose (full stack)
+```bash
+cp config/config-sample.yaml config/config.yaml   # edit bot_token, staffchat_id, owner_id
+docker compose up -d                               # builds image + starts bot + MongoDB (+ optional signal-cli, mongo-express)
+docker compose logs -f supportbot                  # view bot logs
+```
+
+### 3. Tests (local — no DB needed)
+Tests mock all external dependencies (MongoDB, Telegram API, config). No running services required:
+```bash
+npm install && npm test                            # run full suite (10 suites, 68 tests)
+npm test -- test/cache.test.ts                     # single file
+npm test -- -t "test name"                         # specific test case
+```
+
+## Config
+
+- Runtime config lives in `config/config.yaml` (YAML, not JSON).
+- File is loaded synchronously on startup via `src/cache.ts`; it **must exist** before the bot runs.
+- Copy from `config/config-sample.yaml`, then edit at minimum: `bot_token`, `staffchat_id`, `owner_id`.
+- The sample token `YOUR_BOT_TOKEN` causes a hard exit — never commit a real token.
+
+## Architecture
+
+- **Entry point**: `src/index.ts` → connects MongoDB, runs SQLite→Mongo migration if needed, then starts addons.
+- **Addon system** (`src/addons/`): Each platform (Telegram, Signal) is an addon implementing the `Addon` interface from `src/interfaces.ts`. Telegram lives in `addons/telegram/index.ts`, Signal in `addons/signal/`.
+- **Database**: MongoDB via Mongoose (`src/db.ts`). Collection name is derived from `owner_id` + last 5 chars of bot token.
+- **Config cache** (`src/cache.ts`): Singleton that parses YAML config at module load time. Tests mock this module entirely.
+
+## Testing
+
+- Framework: Jest + ts-jest, Node environment.
+- Setup files run before every test: `jest.setup.js` (mocks `fancy-log`, `openai`) and `test/mocks.ts` (mocks `cache`, `db`, `grammy`, `axios`, `ws`).
+- Tests do **not** need a real MongoDB or config file — everything is mocked.
+- Run single test: `npm test -- path/to/file.test.ts` or with `-t "test name"` for a specific case.
+
+## TypeScript quirks
+
+- `strictNullChecks` is **disabled** in `tsconfig.json`. Code may rely on loose null handling.
+- Module system: `Node16` resolution, target ES2022.
+- Build output directory: `build/`. The compiled entry is `build/index.js` (package `"main"` field).
+
+## Docker / deployment
+
+- `docker-compose.yml` provides 4 services: bot, MongoDB, signal-cli REST API, mongo-express web UI.
+- Bot mounts `./config:/bot/config` so the YAML config is available inside the container.
+- `MONGO_URI` env var points to `mongodb://mongodb:27017/support`.
+- Dockerfile is multi-stage (node:22-alpine), requires `python3` + `build-base` for native modules (`better-sqlite3`).
+- All non-bot ports are bound to `127.0.0.1` only — MongoDB, signal-cli, and mongo-express are not exposed externally.
+
+## Dependencies worth knowing
+
+| Package | Role |
+|---|---|
+| `grammy` | Telegram Bot API framework |
+| `mongoose` | MongoDB ODM |
+| `llamaindex` / `openai` | LLM-powered auto-reply (optional, gated by `use_llm: true`) |
+| `better-sqlite3` | Optional — used only for legacy SQLite migration path |

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,5 +39,5 @@ COPY --from=builder /bot/build /bot/build
 # Set NODE_ENV to production
 ENV NODE_ENV=production
 
-# Run the application
-CMD ["npm", "run", "prod", "--prefix", "/bot"]
+# Run the application (build is already done in builder stage)
+CMD ["node", "./build/index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM node:24-alpine AS builder
+FROM node:22-alpine AS builder
 
 WORKDIR /bot
 
@@ -19,7 +19,7 @@ COPY ./tsconfig.json /bot/tsconfig.json
 RUN npm run build
 
 # Production stage
-FROM node:24-alpine AS production
+FROM node:22-alpine AS production
 
 WORKDIR /bot
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM node:22-alpine AS builder
+FROM node:24-alpine AS builder
 
 WORKDIR /bot
 
@@ -19,7 +19,7 @@ COPY ./tsconfig.json /bot/tsconfig.json
 RUN npm run build
 
 # Production stage
-FROM node:22-alpine AS production
+FROM node:24-alpine AS production
 
 WORKDIR /bot
 

--- a/config/config-sample.yaml
+++ b/config/config-sample.yaml
@@ -83,6 +83,24 @@ language:
   automatedReplySent: 'Automated reply was send to the user.'
   ticketReopened: 'Ticket reopened.'
   regardsGroup: 'Botty Group'
+  # CSAT survey strings
+  csatRatingRequest: "How would you rate your support experience?"
+  csatThankYou: "Thank you for your feedback!"
+  # Triage / priority strings
+  triagePriority: "Priority"
+  triageSummary: "Summary"
+  sentimentAlert: "🚨 Frustrated customer detected"
+  # Assignment strings
+  ticketAssignedTo: "assigned to"
+  ticketUnassigned: "unassigned"
+  assignedBy: "by"
+  # Internal note strings
+  internalNote: "Internal Note"
+  noteAddedBy: "Note by"
+  # Workflow strings
+  offlineMessage: "We're currently offline. Leave a message and we'll get back to you."
+  businessHoursClosed: "Our support team is currently offline. We'll respond during business hours."
+  escalationNotify: "⚠️ Ticket escalated — no response for"
 
 autoreply:
   - question: 'install'
@@ -160,3 +178,63 @@ llm_knowledge: >
 
     Q: What's the uptime guarantee?
     A: 99.9% SLA for paid plans.
+
+# --- AI Advanced Settings ---
+llm_memory_depth: 10 # Number of messages to include in conversation history (0 = disabled)
+auto_triage: false # Auto-classify incoming tickets with AI (category, priority, summary)
+sentiment_alert_threshold: 2 # Flag tickets with sentiment score <= this value (1-5 scale)
+staff_assist: false # Generate AI draft replies for staff members
+translate_enabled: false # Auto-translate messages between user and staff
+translate_target_language: 'en' # Target language for translation (ISO code)
+
+# --- Team Collaboration ---
+enable_csat: false # Send CSAT survey when ticket is closed
+daily_summary_time: '09:00' # Time (UTC) to send daily analytics summary to staff chat
+staff_roles: [] # List of staff members and their roles
+  # - telegram_id: "123456"
+  #   role: "admin" # admin, supervisor, agent
+  #   name: "John Doe"
+
+# --- Webhooks ---
+webhooks: [] # Event-driven webhooks to external URLs
+  # - url: "https://example.com/webhook"
+  #   events: ["ticket.created", "ticket.closed"]
+  #   secret: "whsec_..." # Optional HMAC verification secret
+
+# --- Integrations ---
+slack_enabled: false # Mirror tickets to Slack channel
+slack_bot_token: '' # Slack bot token (xoxb-...)
+slack_channel_id: '' # Slack channel ID (#general or Cxxxxxxxx)
+
+discord_enabled: false # Mirror tickets to Discord channel
+discord_bot_token: '' # Discord bot token
+discord_channel_id: '' # Discord channel/voice channel ID
+
+api_enabled: false # Enable REST API for programmatic access
+api_token: '' # Bearer token for API authentication
+
+# --- Web Chat Widget ---
+web_chat:
+  enabled: false
+  greeting: "Hi! How can we help you?"
+  primary_color: "#6366f1"
+  logo_url: ""
+  position: "right" # left or right
+  pre_chat_form:
+    name: true
+    email: true
+    subject: false
+    order_number: false
+
+# --- Workflows & Automation ---
+canned_responses: [] # Pre-written response templates for staff
+  # - key: "shipping"
+  #   text: "Your order should arrive within 3-5 business days."
+  # - key: "refund"
+  #   text: "We process refunds within 14 days. A team member will reach out shortly."
+
+escalation_rules: [] # Auto-escalate tickets based on rules
+  # - after_hours: 4
+  #   action: "notify_supervisor" # notify_supervisor or tag_urgent
+
+auto_close_after_days: 0 # Auto-close inactive tickets (0 = disabled)

--- a/config/config-sample.yaml
+++ b/config/config-sample.yaml
@@ -30,6 +30,8 @@ signal_host: 'localhost:40153' # Signal host (default: localhost:40153)
 web_server: false # Enable/disable web server
 web_server_port: 8080 # Port for web server
 
+log_level: 'NONE' # NONE, ERROR, INFO — controls debug.log file output
+
 dev_mode: true # Enable/disable dev mode
 
 # customize your language

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,10 +12,11 @@ services:
   mongodb:
     image: mongo:8.0
     restart: unless-stopped
+    # Only accessible on localhost (not exposed to external network)
     ports:
-      - "27017:27017"
+      - "127.0.0.1:27017:27017"
     volumes:
-      - ./.tmp/mongodb_data:/data/db 
+      - ./.tmp/mongodb_data:/data/db
 
   signal-cli:
     image: bbernhard/signal-cli-rest-api:latest
@@ -23,22 +24,24 @@ services:
     environment:
       - MODE=json-rpc #supported modes: json-rpc, native, normal
       #- AUTO_RECEIVE_SCHEDULE=0 22 * * * #enable this parameter on demand (see description below)
+    # Only accessible on localhost (optional service)
     ports:
-      - "40153:8080"
+      - "127.0.0.1:40153:8080"
     volumes:
       - signal:/home/.local/share/signal-cli
 
-  # mongodb web interface
+  # mongodb web interface (optional - comment out if not needed)
   mongo-express:
     image: mongo-express
     restart: unless-stopped
+    # Only accessible on localhost
     ports:
-      - "8081:8081"
+      - "127.0.0.1:8081:8081"
     environment:
       - ME_CONFIG_MONGODB_SERVER=mongodb
       - ME_CONFIG_MONGODB_PORT=27017
       - ME_CONFIG_BASICAUTH_USERNAME=admin
-      - ME_CONFIG_BASICAUTH_PASSWORD=password  
+      - ME_CONFIG_BASICAUTH_PASSWORD=password
 
 volumes:
   mongodb_data:

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -13,8 +13,8 @@ jest.mock('fancy-log', () => ({
 }));
 
 // Mock OpenAI globally to prevent API key requirements
-jest.mock('openai', () => ({
-  OpenAI: jest.fn().mockImplementation(() => ({
+jest.mock('openai', () => {
+  const MockOpenAI = jest.fn().mockImplementation(() => ({
     chat: {
       completions: {
         create: jest.fn().mockResolvedValue({
@@ -28,8 +28,12 @@ jest.mock('openai', () => ({
         }),
       },
     },
-  })),
-}));
+  }));
+  return {
+    OpenAI: MockOpenAI,
+    default: MockOpenAI,
+  };
+});
 
 // Console warnings during tests can be noise - optionally suppress them
 const originalWarn = console.warn;

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -12,6 +12,14 @@ jest.mock('fancy-log', () => ({
   debug: jest.fn(),
 }));
 
+// Mock logger module to prevent file I/O during tests
+jest.mock('./src/logger', () => ({
+  __esModule: true,
+  default: { info: jest.fn(), error: jest.fn() },
+  info: jest.fn(),
+  error: jest.fn(),
+}));
+
 // Mock OpenAI globally to prevent API key requirements
 jest.mock('openai', () => {
   const MockOpenAI = jest.fn().mockImplementation(() => ({

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
                 "express": "^5.1.0",
                 "express-rate-limit": "^8.0.1",
                 "fancy-log": "^2.0.0",
-                "grammy": "^1.38.1",
+                "grammy": "^1.43.0",
                 "llamaindex": "^0.11.27",
                 "mongoose": "^8.17.2",
                 "node-fetch": ">=3.3.0",
@@ -53,7 +53,7 @@
                 "ts-node-dev": "^2.0.0"
             },
             "engines": {
-                "node": ">=22.0.0"
+                "node": ">=24.0.0"
             },
             "optionalDependencies": {
                 "better-sqlite3": "^12.2.0"
@@ -831,9 +831,9 @@
             }
         },
         "node_modules/@grammyjs/types": {
-            "version": "3.22.1",
-            "resolved": "https://registry.npmjs.org/@grammyjs/types/-/types-3.22.1.tgz",
-            "integrity": "sha512-QJX0Y8lpjE+/nuTKGmxybKmvdrLHV7gqbhI/UXoWlJLWtowbwk+oW+ngfHKwegD+ewL2SX8+tQo/1E14Ma0qlw==",
+            "version": "3.27.3",
+            "resolved": "https://registry.npmjs.org/@grammyjs/types/-/types-3.27.3.tgz",
+            "integrity": "sha512-yUKMLliGsGbnxu96YUJ7km7B0zy4PzeH/Jvti5705R/LeKDMqkDV4DckMSt+OrliWQpTwQljHE0QLol5zgxBkg==",
             "license": "MIT"
         },
         "node_modules/@humanfs/core": {
@@ -4032,9 +4032,9 @@
             }
         },
         "node_modules/debug": {
-            "version": "4.4.1",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-            "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
             "license": "MIT",
             "dependencies": {
                 "ms": "^2.1.3"
@@ -5922,14 +5922,14 @@
             "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
         },
         "node_modules/grammy": {
-            "version": "1.38.1",
-            "resolved": "https://registry.npmjs.org/grammy/-/grammy-1.38.1.tgz",
-            "integrity": "sha512-aVBMeyYUjZ+rUEI+aV0T4himboXGs8Uf57c+vhtmHplPfgaRT04dyT9pG8R/GAmKeTUPh84GKO0u9IvaEGN6RA==",
+            "version": "1.43.0",
+            "resolved": "https://registry.npmjs.org/grammy/-/grammy-1.43.0.tgz",
+            "integrity": "sha512-7dYm06A945mXuIk/5HUlSjeyIYChW8vCEiU2dkOKKqJJzwAWxTkCc91Eqbz7TgODh2rtFFKWI/fekowWHOkmjQ==",
             "license": "MIT",
             "dependencies": {
-                "@grammyjs/types": "3.22.1",
+                "@grammyjs/types": "3.27.3",
                 "abort-controller": "^3.0.0",
-                "debug": "^4.3.4",
+                "debug": "^4.4.3",
                 "node-fetch": "^2.7.0"
             },
             "engines": {

--- a/package.json
+++ b/package.json
@@ -12,11 +12,11 @@
     "bugs": {
         "url": "https://github.com/bostrot/telegram-support-bot/issues"
     },
-    "main": "build/src/index.js",
+    "main": "build/index.js",
     "scripts": {
         "tsc": "tsc",
         "dev": "NODE_ENV=development ts-node-dev ./src/index.ts",
-        "prod": "npm run build && NODE_ENV=production node ./build/index.js",
+        "prod": "NODE_ENV=production node ./build/index.js",
         "build": "npm run tsc",
         "test": "NODE_ENV=test jest --detectOpenHandles --forceExit --runInBand"
     },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "test": "NODE_ENV=test jest --detectOpenHandles --forceExit --runInBand"
     },
     "engines": {
-        "node": ">=22.0.0"
+        "node": ">=24.0.0"
     },
     "dependencies": {
         "@grammyjs/transformer-throttler": "^1.2.1",
@@ -31,7 +31,7 @@
         "express": "^5.1.0",
         "express-rate-limit": "^8.0.1",
         "fancy-log": "^2.0.0",
-        "grammy": "^1.38.1",
+        "grammy": "^1.43.0",
         "llamaindex": "^0.11.27",
         "openai": "^4.72.0",
         "mongoose": "^8.17.2",

--- a/src/addons/discord/index.ts
+++ b/src/addons/discord/index.ts
@@ -1,0 +1,483 @@
+import axios, { AxiosInstance } from 'axios';
+import { Addon, Context } from '../../interfaces';
+import cache from '../../cache';
+import { registerCommonHandlers } from '../../handlers';
+import * as log from 'fancy-log';
+
+const DISCORD_API = 'https://discord.com/api/v10';
+const GATEWAY_URL = 'wss://gateway.discord.gg';
+
+class DiscordAddon implements Addon {
+  private axiosInstance: AxiosInstance;
+  private errorHandler: ((error: any, ctx?: any) => void) | null = null;
+  private eventHandlers: Record<string, ((ctx: any) => void)[]> = {};
+  private commandHandlers: Map<string, ((ctx: any) => void)[]> = new Map();
+  private hearsHandlers: Array<{ trigger: string | RegExp; callback: (ctx: any) => void }> = [];
+  private ws: any | null = null;
+  private botUserId: string = '';
+  private channels: Map<string, { name: string; id: string }> = new Map();
+  private sequence: number | null = null;
+  private session_id: string | null = null;
+
+  private static instance: DiscordAddon | null = null;
+
+  private constructor() {
+    this.axiosInstance = axios.create({
+      baseURL: DISCORD_API,
+      headers: {
+        'Authorization': `Bot ${cache.config.discord_bot_token}`,
+        'Content-Type': 'application/json',
+        'X-RateLimit-Timeout': '1',
+      },
+    });
+  }
+
+  public static getInstance(): DiscordAddon {
+    if (!DiscordAddon.instance) {
+      DiscordAddon.instance = new DiscordAddon();
+    }
+    return DiscordAddon.instance;
+  }
+
+  /**
+   * Sends a text message to a Discord channel.
+   */
+  async sendMessage(chatId: string | number, text: string, options?: any): Promise<string | null> {
+    try {
+      const channelId = this.resolveChannelId(chatId);
+      if (!channelId) {
+        log.error(`Discord: Cannot resolve channel ID for ${chatId}`);
+        return null;
+      }
+
+      const payload: Record<string, any> = {
+        content: text.substring(0, 2000),
+      };
+
+      // Handle thread replies
+      if (options?.message_id) {
+        payload.message_reference = {
+          message_id: options.message_id,
+          channel_id: channelId,
+        };
+      }
+
+      const response = await this.axiosInstance.post(`/channels/${channelId}/messages`, payload);
+
+      log.info(`Discord message sent to ${channelId}`);
+      return response.data.id;
+    } catch (error) {
+      const err = error as { response?: { data: unknown } };
+      log.error('Error sending Discord message:', err.response?.data || error);
+      if (this.errorHandler) this.errorHandler(error);
+      return null;
+    }
+  }
+
+  /**
+   * Sends a photo to Discord.
+   */
+  async sendPhoto(chatId: string | number, photo: any, options?: any): Promise<string | null> {
+    try {
+      const channelId = this.resolveChannelId(chatId);
+      if (!channelId) return null;
+
+      const form = new FormData();
+      form.append('content', options?.caption || '');
+      form.append('files[0]', photo, options?.filename || 'photo.jpg');
+
+      await this.axiosInstance.post(`/channels/${channelId}/messages`, form, {
+        headers: { 'Content-Type': 'multipart/form-data' },
+      });
+
+      log.info(`Discord photo sent to ${channelId}`);
+      return 'uploaded';
+    } catch (error) {
+      log.error('Error sending Discord photo:', error);
+      if (this.errorHandler) this.errorHandler(error);
+      return null;
+    }
+  }
+
+  /**
+   * Sends a document to Discord.
+   */
+  async sendDocument(chatId: string | number, document: any, options?: any): Promise<string | null> {
+    try {
+      const channelId = this.resolveChannelId(chatId);
+      if (!channelId) return null;
+
+      const form = new FormData();
+      form.append('content', options?.caption || '');
+      form.append('files[0]', document, options?.filename || 'document');
+
+      await this.axiosInstance.post(`/channels/${channelId}/messages`, form, {
+        headers: { 'Content-Type': 'multipart/form-data' },
+      });
+
+      log.info(`Discord document sent to ${channelId}`);
+      return 'uploaded';
+    } catch (error) {
+      log.error('Error sending Discord document:', error);
+      if (this.errorHandler) this.errorHandler(error);
+      return null;
+    }
+  }
+
+  /**
+   * Sends a video to Discord.
+   */
+  async sendVideo(chatId: string | number, video: any, options?: any): Promise<string | null> {
+    try {
+      const channelId = this.resolveChannelId(chatId);
+      if (!channelId) return null;
+
+      const form = new FormData();
+      form.append('content', options?.caption || '');
+      form.append('files[0]', video, options?.filename || 'video.mp4');
+
+      await this.axiosInstance.post(`/channels/${channelId}/messages`, form, {
+        headers: { 'Content-Type': 'multipart/form-data' },
+      });
+
+      log.info(`Discord video sent to ${channelId}`);
+      return 'uploaded';
+    } catch (error) {
+      log.error('Error sending Discord video:', error);
+      if (this.errorHandler) this.errorHandler(error);
+      return null;
+    }
+  }
+
+  /**
+   * Registers a command handler.
+   */
+  command(command: string, callback: (ctx: any) => void): void {
+    const handlers = this.commandHandlers.get(command) || [];
+    handlers.push(callback);
+    this.commandHandlers.set(command, handlers);
+  }
+
+  /**
+   * Registers an event handler.
+   */
+  on(event: string | string[], callback: (ctx: any) => void): void {
+    if (typeof event === 'string') {
+      const handlers = this.eventHandlers[event] || [];
+      handlers.push(callback);
+      this.eventHandlers[event] = handlers;
+    } else {
+      event.forEach((ev) => this.on(ev, callback));
+    }
+  }
+
+  /**
+   * Registers a hears handler (text matching).
+   */
+  hears(trigger: string | string[] | RegExp, callback: (ctx: any) => void): void {
+    if (Array.isArray(trigger)) {
+      trigger.forEach(t => this.hears(t, callback));
+    } else {
+      this.hearsHandlers.push({ trigger, callback });
+    }
+  }
+
+  /**
+   * Sets up an error handler.
+   */
+  catch(handler: (error: any, ctx?: any) => void): void {
+    this.errorHandler = handler;
+  }
+
+  /**
+   * Starts the Discord addon — connects to gateway and registers handlers.
+   */
+  start(): void {
+    if (!cache.config.discord_enabled) return;
+
+    log.info('Starting Discord Addon...');
+    registerCommonHandlers(this);
+    this.connectGateway();
+  }
+
+  /**
+   * Connects to the Discord Gateway WebSocket.
+   */
+  private connectGateway(): void {
+    const WebSocket = require('ws');
+    this.ws = new WebSocket(GATEWAY_URL);
+
+    this.ws.on('open', () => {
+      log.info('Discord Gateway WebSocket connected. Identifying...');
+      // Send identify payload
+      this.send({
+        op: 2, // IDENTIFY
+        d: {
+          token: `Bot ${cache.config.discord_bot_token}`,
+          intents: 0 | 1 | 32 | 64 | 1 << 25, // Guilds, Guild Messages, Message Content, etc.
+          properties: {
+            $os: 'linux',
+            $browser: 'telegram-support-bot',
+            $device: 'telegram-support-bot',
+          },
+        },
+      });
+    });
+
+    this.ws.on('message', (data: Buffer) => {
+      try {
+        const message = JSON.parse(data.toString());
+        this.handleGatewayMessage(message);
+      } catch (err) {
+        log.error('Error parsing Discord gateway message:', err);
+      }
+    });
+
+    this.ws.on('error', (error: Error) => {
+      log.error('Discord Gateway error:', error);
+      if (this.errorHandler) this.errorHandler(error);
+    });
+
+    this.ws.on('close', () => {
+      log.info('Discord Gateway closed. Reconnecting in 5 seconds...');
+      setTimeout(() => this.connectGateway(), 5000);
+    });
+  }
+
+  /**
+   * Sends a message to the WebSocket.
+   */
+  private send(payload: any): void {
+    if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+      this.ws.send(JSON.stringify(payload));
+    }
+  }
+
+  /**
+   * Handles incoming gateway messages from Discord.
+   */
+  private handleGatewayMessage(message: any): void {
+    const { op, d, s, t } = message;
+
+    // Dispatch event (op=0)
+    if (op === 0 && t) {
+      this.handleEvent(t, d);
+    }
+
+    // Update sequence for resume
+    if (s !== null && s !== undefined) {
+      this.sequence = s;
+    }
+
+    // Handle specific opcodes
+    switch (op) {
+      case 0: // DISPATCH
+        break;
+      case 10: // HELLO — send heartbeat interval
+        if (d?.heartbeat_interval) {
+          this.startHeartbeat(d.heartbeat_interval);
+        }
+        break;
+      case 9: // INVALID_SESSION
+        log.error('Discord Gateway: Invalid session.');
+        break;
+      case 11: // HEARTBEAT_ACK
+        break;
+    }
+  }
+
+  /**
+   * Handles specific Discord events.
+   */
+  private handleEvent(eventName: string, data: any): void {
+    switch (eventName) {
+      case 'READY':
+        this.botUserId = data.user.id;
+        log.info(`Discord bot ready as ${data.user.username} (${this.botUserId})`);
+
+        // Cache channels from guilds
+        if (data.guilds) {
+          for (const guildId of data.guilds) {
+            this.fetchGuildChannels(guildId);
+          }
+        }
+        break;
+
+      case 'GUILD_CREATE':
+        this.fetchGuildChannels(data.id);
+        break;
+
+      case 'MESSAGE_CREATE':
+        this.handleMessageCreate(data);
+        break;
+
+      case 'CHANNELS_UPDATE':
+        if (data) {
+          for (const ch of data) {
+            this.channels.set(ch.name, { name: ch.name, id: ch.id });
+            this.channels.set(ch.id, { name: ch.name, id: ch.id });
+          }
+        }
+        break;
+    }
+  }
+
+  /**
+   * Fetches channels for a guild to populate the channel cache.
+   */
+  private async fetchGuildChannels(guildId: string): Promise<void> {
+    try {
+      const response = await this.axiosInstance.get(`/guilds/${guildId}/channels`);
+      for (const ch of response.data) {
+        if (ch.type === 0 || ch.type === 15) { // Text or announcement thread
+          this.channels.set(ch.name, { name: ch.name, id: ch.id });
+          this.channels.set(ch.id, { name: ch.name, id: ch.id });
+        }
+      }
+    } catch (error) {
+      log.error(`Error fetching channels for guild ${guildId}:`, error);
+    }
+  }
+
+  /**
+   * Handles MESSAGE_CREATE events.
+   */
+  private handleMessageCreate(msg: any): void {
+    // Ignore bot messages (including our own)
+    if (msg.author?.bot) return;
+
+    const targetChannel = cache.config.discord_channel_id;
+    if (targetChannel && msg.channel_id !== targetChannel) return;
+
+    const ctx = this.buildContext(msg);
+    if (!ctx) return;
+
+    // Process commands (Discord uses prefix like ! or /)
+    const text = ctx.message.text || '';
+    if (text.startsWith('!') || text.startsWith('/')) {
+      const parts = text.split(' ');
+      const commandName = parts[0].substring(1);
+      const handlers = this.commandHandlers.get(commandName);
+      if (handlers) {
+        ctx.match = parts.slice(1).join(' ');
+        handlers.forEach(handler => handler(ctx));
+        return;
+      }
+    }
+
+    // Process hears handlers
+    for (const { trigger, callback } of this.hearsHandlers) {
+      if (typeof trigger === 'string' && text === trigger) {
+        callback(ctx);
+        return;
+      } else if (trigger instanceof RegExp && trigger.test(text)) {
+        ctx.match = trigger.exec(text)?.toString() || '';
+        callback(ctx);
+        return;
+      }
+    }
+
+    // Process generic message handlers
+    const msgHandlers = this.eventHandlers['message'] || [];
+    msgHandlers.forEach(handler => handler(ctx));
+  }
+
+  /**
+   * Builds a Context object from a Discord message.
+   */
+  private buildContext(msg: any): Context | null {
+    if (!msg.author) return null;
+
+    const text = msg.content || '';
+    const userId = msg.author.id;
+    const chatId = msg.channel_id;
+
+    // Extract reply info
+    let replyToText = '';
+    if (msg.reference?.message_id) {
+      replyToText = `#T${msg.reference.message_id} from`;
+    } else if (msg.message_reference?.message_id) {
+      replyToText = `#T${msg.message_reference.message_id} from`;
+    }
+
+    return {
+      messenger: 'discord' as any,
+      update_id: 0,
+      message: {
+        web_msg: false,
+        message_id: parseInt(msg.id) || 0,
+        from: {
+          id: userId,
+          is_bot: msg.author.bot || false,
+          first_name: msg.author.username || `Discord User ${userId}`,
+          username: msg.author.username || '',
+          language_code: 'en',
+        },
+        chat: {
+          id: chatId,
+          first_name: this.channels.get(chatId)?.name || chatId,
+          username: '',
+          type: msg.channel_type === 0 ? 'group' : 'private',
+        },
+        date: Math.floor(new Date(msg.timestamp).getTime() / 1000),
+        text: text,
+        reply_to_message: {
+          from: { is_bot: false },
+          text: replyToText,
+          caption: '',
+        },
+        external_reply: { message_id: parseInt(msg.id) || 0 },
+        getFile: undefined,
+        caption: '',
+      },
+      chat: {
+        id: chatId,
+        first_name: this.channels.get(chatId)?.name || chatId,
+        username: '',
+        type: msg.channel_type === 0 ? 'group' : 'private',
+      },
+      session: {} as any,
+      callbackQuery: { data: '', from: { id: userId }, id: msg.id || '' },
+      from: { username: msg.author.username || '', id: userId },
+      inlineQuery: null,
+      reply: async (): Promise<void> => {},
+      answerCbQuery: async (): Promise<void> => {},
+      getChat: async (): Promise<{ id: string; first_name: string; username: string; type: string }> => ({ id: '', first_name: '', username: '', type: 'private' }),
+      getFile: async (): Promise<unknown> => ({}),
+    };
+  }
+
+  /**
+   * Starts heartbeat interval to keep gateway connection alive.
+   */
+  private startHeartbeat(intervalMs: number): void {
+    setInterval(() => {
+      this.send({
+        op: 1, // HEARTBEAT
+        d: this.sequence,
+      });
+    }, intervalMs);
+    log.info(`Discord heartbeat started (${intervalMs}ms interval)`);
+  }
+
+  /**
+   * Resolves a chatId to a Discord channel ID.
+   */
+  private resolveChannelId(chatId: string | number): string | null {
+    const idStr = String(chatId);
+
+    // If it's already a snowflake ID (17-20 digit numeric)
+    if (/^\d{17,20}$/.test(idStr)) return idStr;
+
+    // Check configured channel
+    if (idStr === 'default' || !idStr) {
+      return cache.config.discord_channel_id || null;
+    }
+
+    // Look up by name
+    const channel = this.channels.get(idStr);
+    return channel ? channel.id : idStr;
+  }
+}
+
+export default DiscordAddon;

--- a/src/addons/discord/index.ts
+++ b/src/addons/discord/index.ts
@@ -2,7 +2,7 @@ import axios, { AxiosInstance } from 'axios';
 import { Addon, Context } from '../../interfaces';
 import cache from '../../cache';
 import { registerCommonHandlers } from '../../handlers';
-import * as log from 'fancy-log';
+import * as log from '../../logger';
 
 const DISCORD_API = 'https://discord.com/api/v10';
 const GATEWAY_URL = 'wss://gateway.discord.gg';

--- a/src/addons/fakectx.ts
+++ b/src/addons/fakectx.ts
@@ -2,7 +2,7 @@ import {Context, Messenger, SessionData} from '../interfaces';
 
 const fakectx: Context = {
   update_id: 617718635,
-  messenger: null,
+  messenger: Messenger.TELEGRAM,
   message: {
     web_msg: true,
     message_id: 4260,
@@ -57,12 +57,12 @@ const fakectx: Context = {
     id: '',
   },
   inlineQuery: () => {},
-  answerCbQuery: function(arg0: any, arg1: boolean): void {
+  answerCbQuery: async (_text?: string, _showAlert?: boolean): Promise<void> => {
     throw new Error('Function not implemented.');
   },
-  reply: () => {},
-  getChat: () => {},
-  getFile: () => {},
+  reply: async (): Promise<void> => {},
+  getChat: async (): Promise<{ id: string; first_name: string; username: string; type: string }> => ({ id: '', first_name: '', username: '', type: 'private' }),
+  getFile: async (): Promise<unknown> => ({}),
 };
 
 export default fakectx;

--- a/src/addons/llm.ts
+++ b/src/addons/llm.ts
@@ -72,7 +72,8 @@ async function getResponseFromLLM(ctx: Context, ticketId?: number): Promise<stri
         });
 
         const message = response.choices[0]?.message?.content;
-        if (message === "null" || message === "Null" || message === null) {
+        if (message === "null" || message === "Null" || message === null || message === undefined) {
+            log.info('LLM returned no answer (question not covered by llm_knowledge)');
             return null;
         }
         return message;

--- a/src/addons/llm.ts
+++ b/src/addons/llm.ts
@@ -1,13 +1,54 @@
 import { Context } from '../interfaces';
 import OpenAI from 'openai';
 import cache from '../cache';
+import * as db from '../db'; // intentionally circular-safe at runtime since llm is imported lazily
+import * as log from 'fancy-log'
 
-const llm = new OpenAI({
-    apiKey: cache.config.llm_api_key,
-    baseURL: cache.config.llm_base_url,
-});
+// Lazy-initialize OpenAI client to avoid issues when config isn't loaded (e.g., tests)
+let llm: InstanceType<typeof OpenAI> | null = null;
+function getLLM(): InstanceType<typeof OpenAI> {
+    if (!llm) {
+        llm = new OpenAI({
+            apiKey: cache.config.llm_api_key,
+            baseURL: cache.config.llm_base_url,
+        });
+    }
+    return llm;
+}
 
-async function getResponseFromLLM(ctx: Context): Promise<string | null> {
+/**
+ * Builds conversation history messages for the LLM API.
+ * Fetches last N messages from ticket_messages collection.
+ */
+async function buildConversationMessages(
+    userMessage: string,
+    ticketId?: number,
+): Promise<Array<{ role: 'system' | 'user' | 'assistant'; content: string }>> {
+    const messages: Array<{ role: 'system' | 'user' | 'assistant'; content: string }> = [];
+
+    // Add conversation history if ticket ID is provided and memory is enabled
+    if (ticketId && cache.config.llm_memory_depth > 0) {
+        try {
+            const history = await db.getConversationHistory(ticketId, cache.config.llm_memory_depth);
+            for (const entry of history.reverse()) {
+                const role = entry.sender === 'staff' || entry.sender === 'ai' ? 'assistant' : 'user';
+                messages.push({ role, content: entry.text });
+            }
+        } catch (err) {
+            log.error('Failed to load conversation history:', err);
+        }
+    }
+
+    // Add current user message
+    messages.push({ role: 'user', content: userMessage });
+    return messages;
+}
+
+/**
+ * Gets a response from the LLM for auto-replying to users.
+ * Uses conversation memory if available.
+ */
+async function getResponseFromLLM(ctx: Context, ticketId?: number): Promise<string | null> {
     const systemPrompt = `You are a Support Agent. You have been assigned to help 
     the user based on the message and only the provided knowledge base. If the knowledge base
     does not contain the information needed to answer the user's question, you should respond
@@ -18,26 +59,94 @@ async function getResponseFromLLM(ctx: Context): Promise<string | null> {
     """
     `;
 
-    var response = null
+    const conversationMessages = await buildConversationMessages(ctx.message.text, ticketId);
+
+    let response = null;
     try {
-        response = await llm.chat.completions.create({
+        response = await getLLM().chat.completions.create({
             model: cache.config.llm_model || 'gpt-3.5-turbo',
             messages: [
                 { content: systemPrompt, role: "system" },
-                { content: ctx.message.text, role: "user" }
+                ...conversationMessages,
             ],
         });
 
         const message = response.choices[0]?.message?.content;
         if (message === "null" || message === "Null" || message === null) {
-            return null
+            return null;
         }
         return message;
     }
     catch (error) {
-        console.error("Error in LLM response:", error);
+        log.error("Error in LLM response:", error);
         return null;
     }
 }
 
-export { getResponseFromLLM };
+/**
+ * Generates a draft reply suggestion for staff members.
+ */
+async function getStaffAssistDraft(
+    ctx: Context,
+    ticketId?: number,
+): Promise<string | null> {
+    const systemPrompt = `You are an AI assistant helping a support agent respond to a customer. 
+    Based on the conversation history and knowledge base below, draft a helpful response.
+    Write in a professional but friendly tone. Do NOT include salutations or sign-offs — 
+    just the body of the reply.\n\n
+    Knowledgebase: """
+    ${cache.config.llm_knowledge}
+    """
+    `;
+
+    const conversationMessages = await buildConversationMessages(ctx.message.text, ticketId);
+
+    try {
+        const response = await getLLM().chat.completions.create({
+            model: cache.config.llm_model || 'gpt-3.5-turbo',
+            messages: [
+                { content: systemPrompt, role: "system" },
+                ...conversationMessages,
+            ],
+        });
+
+        const message = response.choices[0]?.message?.content;
+        return message || null;
+    } catch (error) {
+        log.error("Error in staff assist draft:", error);
+        return null;
+    }
+}
+
+/**
+ * Translates text to the target language using LLM.
+ */
+async function translateText(
+    text: string,
+    sourceLang?: string,
+): Promise<string | null> {
+    if (!cache.config.translate_enabled) return null;
+    const targetLang = cache.config.translate_target_language || 'en';
+
+    try {
+        const prompt = sourceLang
+            ? `Translate the following text from ${sourceLang} to ${targetLang}. Return ONLY the translated text, nothing else:\n\n${text}`
+            : `Detect the language of this text and translate it to ${targetLang}. Return ONLY the translated text, nothing else:\n\n${text}`;
+
+        const response = await getLLM().chat.completions.create({
+            model: cache.config.llm_model || 'gpt-3.5-turbo',
+            messages: [
+                { role: "system", content: "You are a professional translator. Always return only the translated text with no additional commentary." },
+                { role: "user", content: prompt },
+            ],
+        });
+
+        const translated = response.choices[0]?.message?.content;
+        return translated || null;
+    } catch (error) {
+        log.error("Error in translation:", error);
+        return null;
+    }
+}
+
+export { getResponseFromLLM, getStaffAssistDraft, translateText };

--- a/src/addons/llm.ts
+++ b/src/addons/llm.ts
@@ -2,7 +2,7 @@ import { Context } from '../interfaces';
 import OpenAI from 'openai';
 import cache from '../cache';
 import * as db from '../db'; // intentionally circular-safe at runtime since llm is imported lazily
-import * as log from 'fancy-log'
+import * as log from '../logger'
 
 // Lazy-initialize OpenAI client to avoid issues when config isn't loaded (e.g., tests)
 let llm: InstanceType<typeof OpenAI> | null = null;

--- a/src/addons/signal/index.ts
+++ b/src/addons/signal/index.ts
@@ -6,7 +6,7 @@ import { mapSignalMessageToContext } from './mapper';
 import { Group, SignalMessage } from './models';
 import { registerCommonHandlers } from '../../handlers';
 import * as db from '../../db';
-import * as log from 'fancy-log';
+import * as log from '../../logger';
 
 const SEND_ENDPOINT = 'v2/send';
 const GROUP_ENDPOINT = 'v1/groups';

--- a/src/addons/signal/mapper.ts
+++ b/src/addons/signal/mapper.ts
@@ -16,9 +16,9 @@ export function mapSignalMessageToContext(signalMsg: SignalMessage): Context {
     const username = envelope.sourceName.replace(/\s/g, '').toLowerCase();
   
     // Create a chat object based on envelope data.
-    var chatType = 'private';
-    var chatId = senderId;
-    var replyId = dataMessage.quote?.id;
+    let chatType = 'private';
+    let chatId = senderId;
+    const replyId = dataMessage.quote?.id;
     if (dataMessage.groupInfo) {
       chatId = dataMessage.groupInfo.groupId;
       chatType = 'group';

--- a/src/addons/signal/mapper.ts
+++ b/src/addons/signal/mapper.ts
@@ -48,14 +48,14 @@ export function mapSignalMessageToContext(signalMsg: SignalMessage): Context {
         date: dateInSeconds,
         text: dataMessage.message,
         external_reply: {
-          message_id: replyId,
+          message_id: replyId ?? 0,
         },
         reply_to_message: {
           from: {
             is_bot: false,
           },
-          text: signalMsg.envelope.dataMessage.quote?.text,
-          caption: signalMsg.envelope.dataMessage.quote?.text,
+          text: signalMsg.envelope.dataMessage.quote?.text ?? '',
+          caption: signalMsg.envelope.dataMessage.quote?.text ?? '',
         },
         getFile: () => {},
         caption: dataMessage.message,
@@ -78,16 +78,15 @@ export function mapSignalMessageToContext(signalMsg: SignalMessage): Context {
         id: senderId,
       },
       inlineQuery: () => {},
-      answerCbQuery: function(arg0: any, arg1: boolean): void {
+      answerCbQuery: async (_text?: string, _showAlert?: boolean): Promise<void> => {
         throw new Error('Function not implemented.');
       },
-      reply: () => {},
-      getChat: () => {},
-      getFile: async () => {
-        return {
-          file_id: signalMsg.envelope.dataMessage.attachments[0].id,
-        };
-      }
+      reply: async (): Promise<void> => {},
+      getChat: async (): Promise<{ id: string; first_name: string; username: string; type: string }> => ({ id: senderId, first_name: '', username: '', type: 'private' }),
+      getFile: async (): Promise<unknown> => {
+        const attachments = signalMsg.envelope.dataMessage.attachments ?? [];
+        return { file_id: attachments[0]?.id };
+      },
 
     };
   

--- a/src/addons/slack/index.ts
+++ b/src/addons/slack/index.ts
@@ -2,7 +2,7 @@ import axios, { AxiosInstance } from 'axios';
 import { Addon, Context } from '../../interfaces';
 import cache from '../../cache';
 import { registerCommonHandlers } from '../../handlers';
-import * as log from 'fancy-log';
+import * as log from '../../logger';
 
 const SLACK_API = 'https://slack.com/api';
 

--- a/src/addons/slack/index.ts
+++ b/src/addons/slack/index.ts
@@ -1,0 +1,400 @@
+import axios, { AxiosInstance } from 'axios';
+import { Addon, Context } from '../../interfaces';
+import cache from '../../cache';
+import { registerCommonHandlers } from '../../handlers';
+import * as log from 'fancy-log';
+
+const SLACK_API = 'https://slack.com/api';
+
+class SlackAddon implements Addon {
+  private axiosInstance: AxiosInstance;
+  private errorHandler: ((error: any, ctx?: any) => void) | null = null;
+  private eventHandlers: Record<string, ((ctx: any) => void)[]> = {};
+  private commandHandlers: Map<string, ((ctx: any) => void)[]> = new Map();
+  private hearsHandlers: Array<{ trigger: string | RegExp; callback: (ctx: any) => void }> = [];
+  private ws: any | null = null;
+  private channels: Map<string, { name: string; id: string }> = new Map();
+
+  private static instance: SlackAddon | null = null;
+
+  private constructor() {
+    this.axiosInstance = axios.create({
+      baseURL: SLACK_API,
+      headers: {
+        'Authorization': `Bearer ${cache.config.slack_bot_token}`,
+        'Content-Type': 'application/json',
+      },
+    });
+  }
+
+  public static getInstance(): SlackAddon {
+    if (!SlackAddon.instance) {
+      SlackAddon.instance = new SlackAddon();
+    }
+    return SlackAddon.instance;
+  }
+
+  /**
+   * Sends a text message to a Slack channel or DM.
+   */
+  async sendMessage(chatId: string | number, text: string, options?: any): Promise<string | null> {
+    try {
+      const channelId = this.resolveChannelId(chatId);
+      if (!channelId) {
+        log.error(`Slack: Cannot resolve channel ID for ${chatId}`);
+        return null;
+      }
+
+      const params: Record<string, any> = {
+        channel: channelId,
+        text: text.substring(0, 4000),
+        mrkdwn: true,
+        unfurl_links: false,
+        unfurl_media: true,
+      };
+
+      // Handle thread replies via thread_ts in options
+      if (options?.thread_ts) {
+        params.thread_ts = options.thread_ts;
+      }
+
+      const response = await this.axiosInstance.post('/chat.postMessage', params);
+
+      if (!response.data.ok) {
+        log.error('Slack sendMessage error:', response.data.error);
+        return null;
+      }
+
+      log.info(`Slack message sent to ${channelId}`);
+      return response.data.ts;
+    } catch (error) {
+      log.error('Error sending Slack message:', error);
+      if (this.errorHandler) this.errorHandler(error);
+      return null;
+    }
+  }
+
+  /**
+   * Sends a photo to Slack.
+   */
+  async sendPhoto(chatId: string | number, photo: any, options?: any): Promise<string | null> {
+    try {
+      const channelId = this.resolveChannelId(chatId);
+      if (!channelId) return null;
+
+      // Upload file via files.upload_v2
+      const form = new FormData();
+      form.append('channels', channelId);
+      form.append('filename', options?.filename || 'photo.jpg');
+      form.append('file', photo);
+      if (options?.caption) {
+        form.append('title', options.caption);
+      }
+
+      await this.axiosInstance.post('/files.upload_v2', form, {
+        headers: { 'Content-Type': 'multipart/form-data' },
+      });
+
+      log.info(`Slack photo sent to ${channelId}`);
+      return 'uploaded';
+    } catch (error) {
+      log.error('Error sending Slack photo:', error);
+      if (this.errorHandler) this.errorHandler(error);
+      return null;
+    }
+  }
+
+  /**
+   * Sends a document to Slack.
+   */
+  async sendDocument(chatId: string | number, document: any, options?: any): Promise<string | null> {
+    try {
+      const channelId = this.resolveChannelId(chatId);
+      if (!channelId) return null;
+
+      const form = new FormData();
+      form.append('channels', channelId);
+      form.append('filename', options?.filename || 'document');
+      form.append('file', document);
+      if (options?.caption) {
+        form.append('title', options.caption);
+      }
+
+      await this.axiosInstance.post('/files.upload_v2', form, {
+        headers: { 'Content-Type': 'multipart/form-data' },
+      });
+
+      log.info(`Slack document sent to ${channelId}`);
+      return 'uploaded';
+    } catch (error) {
+      log.error('Error sending Slack document:', error);
+      if (this.errorHandler) this.errorHandler(error);
+      return null;
+    }
+  }
+
+  /**
+   * Sends a video to Slack.
+   */
+  async sendVideo(chatId: string | number, video: any, options?: any): Promise<string | null> {
+    try {
+      const channelId = this.resolveChannelId(chatId);
+      if (!channelId) return null;
+
+      const form = new FormData();
+      form.append('channels', channelId);
+      form.append('filename', options?.filename || 'video.mp4');
+      form.append('file', video);
+      if (options?.caption) {
+        form.append('title', options.caption);
+      }
+
+      await this.axiosInstance.post('/files.upload_v2', form, {
+        headers: { 'Content-Type': 'multipart/form-data' },
+      });
+
+      log.info(`Slack video sent to ${channelId}`);
+      return 'uploaded';
+    } catch (error) {
+      log.error('Error sending Slack video:', error);
+      if (this.errorHandler) this.errorHandler(error);
+      return null;
+    }
+  }
+
+  /**
+   * Registers a command handler.
+   */
+  command(command: string, callback: (ctx: any) => void): void {
+    const handlers = this.commandHandlers.get(command) || [];
+    handlers.push(callback);
+    this.commandHandlers.set(command, handlers);
+  }
+
+  /**
+   * Registers an event handler.
+   */
+  on(event: string | string[], callback: (ctx: any) => void): void {
+    if (typeof event === 'string') {
+      const handlers = this.eventHandlers[event] || [];
+      handlers.push(callback);
+      this.eventHandlers[event] = handlers;
+    } else {
+      event.forEach((ev) => this.on(ev, callback));
+    }
+  }
+
+  /**
+   * Registers a hears handler (text matching).
+   */
+  hears(trigger: string | string[] | RegExp, callback: (ctx: any) => void): void {
+    if (Array.isArray(trigger)) {
+      trigger.forEach(t => this.hears(t, callback));
+    } else {
+      this.hearsHandlers.push({ trigger, callback });
+    }
+  }
+
+  /**
+   * Sets up an error handler.
+   */
+  catch(handler: (error: any, ctx?: any) => void): void {
+    this.errorHandler = handler;
+  }
+
+  /**
+   * Starts the Slack addon — connects via RTM WebSocket and registers handlers.
+   */
+  start(): void {
+    if (!cache.config.slack_enabled) return;
+
+    log.info('Starting Slack Addon...');
+    registerCommonHandlers(this);
+    this.connectRTM();
+  }
+
+  /**
+   * Connects to Slack RTM via WebSocket for real-time message reception.
+   */
+  private connectRTM(): void {
+    // Get WSS URL from Slack
+    this.axiosInstance.get('/rtm.connect').then((response) => {
+      if (!response.data.ok) {
+        log.error('Slack RTM connect failed:', response.data.error);
+        return;
+      }
+
+      const wsURL = response.data.url;
+      log.info('Connecting to Slack RTM WebSocket...');
+
+      // Cache channel list
+      response.data.channels?.forEach((ch: any) => {
+        this.channels.set(ch.name, { name: ch.name, id: ch.id });
+        this.channels.set(ch.id, { name: ch.name, id: ch.id });
+      });
+
+      const WebSocket = require('ws');
+      this.ws = new WebSocket(wsURL);
+
+      this.ws.on('open', () => {
+        log.info('Slack RTM WebSocket connected.');
+      });
+
+      this.ws.on('message', (data: Buffer) => {
+        try {
+          const message = JSON.parse(data.toString());
+          this.handleRTMMessage(message);
+        } catch (err) {
+          log.error('Error parsing Slack RTM message:', err);
+        }
+      });
+
+      this.ws.on('error', (error: Error) => {
+        log.error('Slack WebSocket error:', error);
+        if (this.errorHandler) this.errorHandler(error);
+      });
+
+      this.ws.on('close', () => {
+        log.info('Slack RTM WebSocket closed. Reconnecting in 5 seconds...');
+        setTimeout(() => this.connectRTM(), 5000);
+      });
+    }).catch((error: Error) => {
+      log.error('Failed to connect Slack RTM:', error);
+      if (this.errorHandler) this.errorHandler(error);
+      // Retry after 10 seconds
+      setTimeout(() => this.connectRTM(), 10000);
+    });
+  }
+
+  /**
+   * Handles incoming RTM messages from Slack.
+   */
+  private handleRTMMessage(message: any): void {
+    // Only process message events in the configured channel
+    if (message.type !== 'message' || !message.channel) return;
+
+    const targetChannel = cache.config.slack_channel_id;
+    if (targetChannel && message.channel !== targetChannel) return;
+
+    // Ignore bot messages (including our own)
+    if (message.subtype === 'bot_message' || message.bot_id) return;
+
+    // Build a Context-like object from the Slack message
+    const ctx = this.buildContext(message);
+    if (!ctx) return;
+
+    // Process commands
+    const text = ctx.message.text || '';
+    if (text.startsWith('/')) {
+      const parts = text.split(' ');
+      const commandName = parts[0].substring(1).split(':')[0];
+      const handlers = this.commandHandlers.get(commandName);
+      if (handlers) {
+        ctx.match = parts.slice(1).join(' ');
+        handlers.forEach(handler => handler(ctx));
+        return;
+      }
+    }
+
+    // Process hears handlers
+    for (const { trigger, callback } of this.hearsHandlers) {
+      if (typeof trigger === 'string' && text === trigger) {
+        callback(ctx);
+        return;
+      } else if (trigger instanceof RegExp && trigger.test(text)) {
+        ctx.match = trigger.exec(text)?.toString() || '';
+        callback(ctx);
+        return;
+      }
+    }
+
+    // Process generic message handlers
+    const msgHandlers = this.eventHandlers['message'] || [];
+    msgHandlers.forEach(handler => handler(ctx));
+  }
+
+  /**
+   * Builds a Context object from a Slack RTM message.
+   */
+  private buildContext(msg: any): Context | null {
+    if (!msg.user) return null;
+
+    const text = msg.text || '';
+    const userId = msg.user;
+    const chatId = msg.channel;
+    const threadTs = msg.thread_ts || msg.ts;
+
+    // Extract reply info (thread parent)
+    let replyToText = '';
+    if (msg.parent_user_id) {
+      replyToText = `#T${msg.parent_user_id} from`;
+    }
+
+    return {
+      messenger: 'slack' as any,
+      update_id: 0,
+      message: {
+        web_msg: false,
+        message_id: parseInt(msg.ts?.replace('.', '') || '0'),
+        from: {
+          id: userId,
+          is_bot: false,
+          first_name: msg.username || `Slack User ${userId}`,
+          username: msg.username || '',
+          language_code: 'en',
+        },
+        chat: {
+          id: chatId,
+          first_name: this.channels.get(chatId)?.name || chatId,
+          username: '',
+          type: msg.channel.startsWith('C') ? 'group' : 'private',
+        },
+        date: Math.floor(Date.now() / 1000),
+        text: text,
+        reply_to_message: {
+          from: { is_bot: false },
+          text: replyToText,
+          caption: '',
+        },
+        external_reply: { message_id: parseInt(msg.ts?.replace('.', '') || '0') },
+        getFile: undefined,
+        caption: '',
+      },
+      chat: {
+        id: chatId,
+        first_name: this.channels.get(chatId)?.name || chatId,
+        username: '',
+        type: msg.channel.startsWith('C') ? 'group' : 'private',
+      },
+      session: {} as any,
+      callbackQuery: { data: '', from: { id: userId }, id: msg.ts || '' },
+      from: { username: msg.username || '', id: userId },
+      inlineQuery: null,
+      reply: async (): Promise<void> => {},
+      answerCbQuery: async (): Promise<void> => {},
+      getChat: async (): Promise<{ id: string; first_name: string; username: string; type: string }> => ({ id: '', first_name: '', username: '', type: 'private' }),
+      getFile: async (): Promise<unknown> => ({}),
+    };
+  }
+
+  /**
+   * Resolves a chatId to a Slack channel ID.
+   */
+  private resolveChannelId(chatId: string | number): string | null {
+    const idStr = String(chatId);
+
+    // If it's already a Slack channel ID (starts with C, G, D)
+    if (/^[CDG].+$/.test(idStr)) return idStr;
+
+    // Check configured channel
+    if (idStr === 'default' || !idStr) {
+      return cache.config.slack_channel_id || null;
+    }
+
+    // Look up by name
+    const channel = this.channels.get(idStr);
+    return channel ? channel.id : idStr;
+  }
+}
+
+export default SlackAddon;

--- a/src/addons/telegram/index.ts
+++ b/src/addons/telegram/index.ts
@@ -6,7 +6,7 @@ import * as permissions from '../../permissions';
 import * as inline from '../../inline';
 import cache from '../../cache';
 import { registerCommonHandlers } from '../../handlers';
-import * as log from 'fancy-log'
+import * as log from '../../logger'
 
 type BotContext = GrammyContext & SessionFlavor<SessionData>;
 

--- a/src/addons/telegram/index.ts
+++ b/src/addons/telegram/index.ts
@@ -1,5 +1,5 @@
 import { Bot, Context as GrammyContext, SessionFlavor, session } from 'grammy';
-import { Addon, Context, Messenger, SessionData } from '../../interfaces';
+import { Addon, Context, Messenger, ModeData, SessionData } from '../../interfaces';
 import { apiThrottler } from '@grammyjs/transformer-throttler';
 import * as middleware from '../../middleware';
 import * as permissions from '../../permissions';
@@ -12,7 +12,7 @@ type BotContext = GrammyContext & SessionFlavor<SessionData>;
 
 class TelegramAddon implements Addon {
   public bot: Bot<BotContext>;
-  public botInfo: any = {};
+  public botInfo: Record<string, unknown> = {};
 
   private static instance: TelegramAddon | null = null;
 
@@ -20,9 +20,17 @@ class TelegramAddon implements Addon {
     this.bot = new Bot<BotContext>(token);
     const throttler = apiThrottler();
     this.bot.api.config.use(throttler);
-    this.bot.init().then(() => {
-      this.botInfo = this.bot.botInfo;
-    });
+    // Defer bot info init to avoid unhandled promise in constructor
+    this.initBotInfo();
+  }
+
+  private async initBotInfo(): Promise<void> {
+    try {
+      await this.bot.init();
+      this.botInfo = this.bot.botInfo as unknown as Record<string, unknown>;
+    } catch (err) {
+      log.error('Failed to initialize Telegram bot info:', err);
+    }
   }
 
   public static getInstance(token?: string): TelegramAddon {
@@ -41,13 +49,13 @@ class TelegramAddon implements Addon {
   initSession() {
     const initial = (): SessionData => ({
       admin: null,
-      modeData: {} as any,
+      modeData: { ticketid: '', userid: '', name: null, category: '' } as ModeData,
       mode: null,
-      lastContactDate: null,
+      lastContactDate: 0,
       groupCategory: null,
       groupTag: '',
       group: '',
-      groupAdmin: {} as any,
+      groupAdmin: null,
       getSessionKey: (ctx: Context) => {
         if (ctx.callbackQuery && ctx.callbackQuery.id) {
           return `${ctx.from.id}:${ctx.from.id}`;
@@ -63,44 +71,65 @@ class TelegramAddon implements Addon {
   }
 
   // --- Methods required by the Addon interface ---
-  async sendMessage(chatId: string | number, text: string, options: any = {}): Promise<string | null> {
-    options.disable_web_page_preview = true;
-    if (typeof chatId !== 'string' && typeof chatId !== 'number') return;
+  async sendMessage(chatId: string | number, text: string, options: Record<string, unknown> = {}): Promise<string | null> {
+    options.disable_web_page_preview = true as unknown as string;
+    if (typeof chatId !== 'string' && typeof chatId !== 'number') return null;
+    // Telegram only supports HTML and MarkdownV2 — convert deprecated Markdown to HTML
+    const validModes = ['HTML', 'MarkdownV2'];
+    if (options?.parse_mode === 'Markdown') {
+      options.parse_mode = 'HTML';
+    } else if (options?.parse_mode && !validModes.includes(options.parse_mode as string)) {
+      delete options.parse_mode;
+    }
     const response = await this.bot.api.sendMessage(chatId.toString(), text, options);
     return response.message_id.toString();
   }
 
-  sendDocument = (
+  async sendDocument(
     chatId: string | number,
-    document: any,
-    other?: any,
-    signal?: any
-  ) => {
-    this.bot.api.sendDocument(chatId, document, other, signal);
+    document: unknown,
+    other?: Record<string, unknown>,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    try {
+      await this.bot.api.sendDocument(chatId, document as never, other as never, signal as any);
+    } catch (err) {
+      log.error('Failed to send document:', err);
+    }
+  }
+
+  async sendPhoto(chatId: string | number, photo: unknown, options?: Record<string, unknown>): Promise<void> {
+    try {
+      await this.bot.api.sendPhoto(chatId, photo as never, options as never);
+    } catch (err) {
+      log.error('Failed to send photo:', err);
+    }
+  }
+
+  async sendVideo(chatId: string | number, video: unknown, options?: Record<string, unknown>): Promise<void> {
+    try {
+      await this.bot.api.sendVideo(chatId, video as never, options as never);
+    } catch (err) {
+      log.error('Failed to send video:', err);
+    }
+  }
+
+  command(command: string, callback: (ctx: Context) => void): void {
+    this.bot.command(command, (gCtx) => callback(gCtx as unknown as Context));
+  }
+
+  on(filter: string | string[], ...callbacks: ((ctx: Context) => void)[]): void {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (this.bot.on as any)(filter, ...(callbacks.map(cb => (gCtx: never) => cb(gCtx as unknown as Context))));
   };
 
-  sendPhoto(chatId: string | number, photo: any, options?: any) {
-    this.bot.api.sendPhoto(chatId, photo, options);
+  catch(handler: (error: Error, ctx?: Context) => void): void {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (this.bot.catch as any)((err: Error, gCtx: BotContext | undefined) => handler(err, gCtx as unknown as Context | undefined));
   }
 
-  sendVideo(chatId: string | number, video: any, options?: any) {
-    this.bot.api.sendVideo(chatId, video, options);
-  }
-
-  command(command: string, callback: (ctx: any) => void): void {
-    this.bot.command(command, ctx => callback(ctx));
-  }
-
-  on = (filter: any, ...middleware: any) => {
-    this.bot.on(filter, ...middleware);
-  };
-
-  catch(handler: (error: any, ctx?: Context) => void): void {
-    this.bot.catch(handler);
-  }
-
-  hears(trigger: string | string[] | RegExp, callback: (ctx: any) => void): void {
-    this.bot.hears(trigger, ctx => callback(ctx));
+  hears(trigger: string | string[] | RegExp, callback: (ctx: Context) => void): void {
+    this.bot.hears(trigger, (gCtx) => callback(gCtx as unknown as Context));
   }
 
   // --- Start and Configure the Bot ---
@@ -109,15 +138,18 @@ class TelegramAddon implements Addon {
 
     // Setup session and middleware.
     this.bot.use(this.initSession());
-    this.bot.use((ctx: any, next: () => any) => {
-      ctx.messenger = Messenger.TELEGRAM;
+    this.bot.use(async (ctx: BotContext, next) => {
+      // Set messenger type on context for downstream handlers
+      const typedCtx = ctx as unknown as Context;
+      typedCtx.messenger = Messenger.TELEGRAM;
+
       if (cache.config.dev_mode) {
-        middleware.reply(
-          ctx,
+        await middleware.reply(
+          typedCtx,
           `_Dev mode is on: You might notice some delay in messages, no replies or other errors._`
         );
       }
-      permissions.checkPermissions(ctx, next, cache.config);
+      permissions.checkPermissions(typedCtx, next, cache.config);
     });
 
     const keys = inline.initInline(this);

--- a/src/addons/web/index.ts
+++ b/src/addons/web/index.ts
@@ -3,7 +3,7 @@ import {ticketHandler} from '../../text';
 import cache from '../../cache';
 import TelegramAddon from '../telegram';
 import rateLimit from 'express-rate-limit';
-import * as log from 'fancy-log'
+import * as log from '../../logger'
 
 /* include script
 <script id="chatScript" src="localhost:8080/chat.js"></script>

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -1,0 +1,251 @@
+import cache from './cache';
+import * as db from './db';
+import * as middleware from './middleware';
+import { Context } from './interfaces';
+import * as log from 'fancy-log'
+
+/**
+ * Records a CSAT rating for a ticket.
+ */
+export async function recordCSATRating(
+    ticketId: number,
+    rating: number,
+    comment: string = '',
+): Promise<void> {
+    await db.recordCSAT(ticketId, rating, comment);
+}
+
+/**
+ * Sends a CSAT survey to the user when their ticket is closed.
+ */
+export async function sendCSATSurvey(userId: string | number, messenger: string, ticketId: number): Promise<void> {
+    if (!cache.config.enable_csat) return;
+
+    const msg = cache.config.language.csatRatingRequest || 'How would you rate your support experience?';
+
+    // Build inline keyboard with star ratings
+    const keyboard = {
+        parse_mode: cache.config.parse_mode,
+        reply_markup: {
+            inline_keyboard: [
+                [{ text: '⭐', callback_data: `csat:${ticketId}:1` }],
+                [{ text: '⭐⭐', callback_data: `csat:${ticketId}:2` }],
+                [{ text: '⭐⭐⭐', callback_data: `csat:${ticketId}:3` }],
+                [{ text: '⭐⭐⭐⭐', callback_data: `csat:${ticketId}:4` }],
+                [{ text: '⭐⭐⭐⭐⭐', callback_data: `csat:${ticketId}:5` }],
+            ],
+        },
+    };
+
+    await middleware.sendMessage(userId, messenger, msg, keyboard);
+}
+
+/**
+ * Handles CSAT rating callback from user.
+ */
+export async function handleCSATCallback(ticketId: number, rating: number): Promise<void> {
+    await recordCSATRating(ticketId, rating);
+}
+
+/**
+ * Calculates average first response time in minutes for a given period.
+ */
+export async function getAverageResponseTime(startDate?: Date, endDate?: Date): Promise<number | null> {
+    try {
+        const createdEvents = await db.getAnalyticsEvents('ticket_created', startDate, endDate);
+        const replyEvents = await db.getAnalyticsEvents('first_reply', startDate, endDate);
+
+        if (createdEvents.length === 0 || replyEvents.length === 0) return null;
+
+        let totalMinutes = 0;
+        let count = 0;
+
+        for (const created of createdEvents) {
+            const matchingReply = replyEvents.find(
+                (r) => r.ticketId === created.ticketId && new Date(r.timestamp) > new Date(created.timestamp),
+            );
+            if (matchingReply) {
+                const diffMs = new Date(matchingReply.timestamp).getTime() - new Date(created.timestamp).getTime();
+                totalMinutes += diffMs / 60000;
+                count++;
+            }
+        }
+
+        return count > 0 ? Math.round(totalMinutes / count * 10) / 10 : null;
+    } catch (err) {
+        log.error('Error calculating average response time:', err);
+        return null;
+    }
+}
+
+/**
+ * Calculates average resolution time in minutes for a given period.
+ */
+export async function getAverageResolutionTime(startDate?: Date, endDate?: Date): Promise<number | null> {
+    try {
+        const createdEvents = await db.getAnalyticsEvents('ticket_created', startDate, endDate);
+        const closedEvents = await db.getAnalyticsEvents('ticket_closed', startDate, endDate);
+
+        if (createdEvents.length === 0 || closedEvents.length === 0) return null;
+
+        let totalMinutes = 0;
+        let count = 0;
+
+        for (const created of createdEvents) {
+            const matchingClosed = closedEvents.find(
+                (c) => c.ticketId === created.ticketId && new Date(c.timestamp) > new Date(created.timestamp),
+            );
+            if (matchingClosed) {
+                const diffMs = new Date(matchingClosed.timestamp).getTime() - new Date(created.timestamp).getTime();
+                totalMinutes += diffMs / 60000;
+                count++;
+            }
+        }
+
+        return count > 0 ? Math.round(totalMinutes / count * 10) / 10 : null;
+    } catch (err) {
+        log.error('Error calculating average resolution time:', err);
+        return null;
+    }
+}
+
+/**
+ * Gets the average CSAT rating for a given period.
+ */
+export async function getAverageCSAT(startDate?: Date, endDate?: Date): Promise<number | null> {
+    try {
+        const events = await db.getAnalyticsEvents('csat.rated', startDate, endDate);
+        if (events.length === 0) return null;
+
+        const totalRating = events.reduce((sum, e) => sum + (e.metadata?.rating || 0), 0);
+        return Math.round(totalRating / events.length * 10) / 10;
+    } catch (err) {
+        log.error('Error calculating average CSAT:', err);
+        return null;
+    }
+}
+
+/**
+ * Gets ticket count for a given period.
+ */
+export async function getTicketCount(startDate?: Date, endDate?: Date): Promise<number> {
+    try {
+        const events = await db.getAnalyticsEvents('ticket_created', startDate, endDate);
+        return events.length;
+    } catch (err) {
+        log.error('Error getting ticket count:', err);
+        return 0;
+    }
+}
+
+/**
+ * Gets per-agent statistics for a given period.
+ */
+export async function getAgentStats(startDate?: Date, endDate?: Date): Promise<Array<{ agent_id: string; ticketsResolved: number; avgResponseTime: number | null }>> {
+    try {
+        const replyEvents = await db.getAnalyticsEvents('staff_reply', startDate, endDate);
+        const closedEvents = await db.getAnalyticsEvents('ticket_closed', startDate, endDate);
+
+        const agentMap = new Map<string, { ticketsResolved: number; responseTimes: number[] }>();
+
+        for (const event of replyEvents) {
+            if (!event.agent_id) continue;
+            if (!agentMap.has(event.agent_id)) {
+                agentMap.set(event.agent_id, { ticketsResolved: 0, responseTimes: [] });
+            }
+        }
+
+        for (const event of closedEvents) {
+            if (!event.agent_id) continue;
+            const stats = agentMap.get(event.agent_id);
+            if (stats) {
+                stats.ticketsResolved++;
+            } else {
+                agentMap.set(event.agent_id, { ticketsResolved: 1, responseTimes: [] });
+            }
+        }
+
+        return Array.from(agentMap.entries()).map(([agentId, stats]) => ({
+            agent_id: agentId,
+            ticketsResolved: stats.ticketsResolved,
+            avgResponseTime: null, // TODO: calculate from first_reply events per agent
+        }));
+    } catch (err) {
+        log.error('Error getting agent stats:', err);
+        return [];
+    }
+}
+
+/**
+ * Generates a daily summary message for the staff chat.
+ */
+export async function generateDailySummary(): Promise<string> {
+    const now = new Date();
+    const yesterday = new Date(now.getTime() - 86400000);
+    const weekAgo = new Date(now.getTime() - 7 * 86400000);
+
+    const todayCount = await getTicketCount(new Date(now.toDateString()), now);
+    const weekCount = await getTicketCount(weekAgo, now);
+    const avgResponseTime = await getAverageResponseTime(weekAgo, now);
+    const avgResolutionTime = await getAverageResolutionTime(weekAgo, now);
+    const avgCSAT = await getAverageCSAT(weekAgo, now);
+
+    let summary = `📊 *Daily Support Summary*\n\n`;
+    summary += `📋 Tickets today: ${todayCount}\n`;
+    summary += `📈 Tickets this week: ${weekCount}\n`;
+
+    if (avgResponseTime !== null) {
+        summary += `⏱️ Avg first response: ${avgResponseTime} min\n`;
+    }
+    if (avgResolutionTime !== null) {
+        summary += `✅ Avg resolution: ${Math.round(avgResolutionTime / 60)}h ${Math.round(avgResolutionTime % 60)}m\n`;
+    }
+    if (avgCSAT !== null) {
+        summary += `⭐ CSAT score: ${avgCSAT}/5.0\n`;
+    }
+
+    return summary;
+}
+
+/**
+ * Sends the daily summary to the staff chat.
+ */
+export async function sendDailySummary(): Promise<void> {
+    try {
+        const summary = await generateDailySummary();
+        await middleware.sendMessage(
+            cache.config.staffchat_id,
+            cache.config.staffchat_type,
+            summary,
+            { parse_mode: cache.config.parse_mode },
+        );
+        log.info('Daily summary sent to staff chat.');
+    } catch (err) {
+        log.error('Error sending daily summary:', err);
+    }
+}
+
+/**
+ * Shows analytics stats command for staff.
+ */
+export async function showStatsCommand(ctx: Context): Promise<void> {
+    const weekAgo = new Date(Date.now() - 7 * 86400000);
+
+    const todayCount = await getTicketCount(new Date(new Date().toDateString()), new Date());
+    const weekCount = await getTicketCount(weekAgo, new Date());
+    const avgResponseTime = await getAverageResponseTime(weekAgo, new Date());
+    const avgCSAT = await getAverageCSAT(weekAgo, new Date());
+
+    let stats = `📊 *Support Stats (last 7 days)*\n\n`;
+    stats += `📋 Tickets today: ${todayCount}\n`;
+    stats += `📈 Tickets this week: ${weekCount}\n`;
+
+    if (avgResponseTime !== null) {
+        stats += `⏱️ Avg first response: ${avgResponseTime} min\n`;
+    }
+    if (avgCSAT !== null) {
+        stats += `⭐ CSAT score: ${avgCSAT}/5.0\n`;
+    }
+
+    middleware.reply(ctx, stats, { parse_mode: cache.config.parse_mode });
+}

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -2,7 +2,7 @@ import cache from './cache';
 import * as db from './db';
 import * as middleware from './middleware';
 import { Context } from './interfaces';
-import * as log from 'fancy-log'
+import * as log from './logger'
 
 /**
  * Records a CSAT rating for a ticket.

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,6 +1,8 @@
 import { Cache, Config, Language, Messenger, ParseMode, SocketTo } from './interfaces';
 import * as YAML from 'yaml';
 import * as fs from 'fs';
+import * as log from './logger';
+import { mergeLanguage } from './language';
 
 const cache: Cache = {
   userId: '',
@@ -17,65 +19,6 @@ const cache: Cache = {
   recoveryBaseline: 0,
 };
 
-// Default language strings — used when config doesn't provide them
-const defaultLanguage: Partial<Language> = {
-  startCommandText: '/start - Start the bot',
-  faqCommandText: '/faq - Frequently Asked Questions',
-  helpCommandText: '/help - Get help',
-  confirmationMessage: 'Your message has been sent. We will get back to you as soon as possible.',
-  contactMessage: '',
-  blockedSpam: 'You are blocked due to spam.',
-  ticket: 'Ticket',
-  closed: 'Closed',
-  acceptedBy: 'Accepted by',
-  dear: 'Dear',
-  regards: 'Regards',
-  from: 'from',
-  language: 'Language',
-  msg_sent: 'Message sent!',
-  file_sent: 'File sent!',
-  usr_with_ticket: 'User with ticket',
-  banned: 'Banned',
-  replyPrivate: 'Reply in private chat',
-  services: 'Services',
-  customer: 'Customer',
-  msgForwarding: 'Message forwarding',
-  back: 'Back',
-  whatSubCategory: 'What sub-category?',
-  prvChatEnded: 'Private chat ended.',
-  prvChatOpened: 'Private chat opened.',
-  prvChatEnd: 'End private chat',
-  prvChatOpenedCustomer: 'Staff has opened a private chat with you.',
-  instructionsSent: 'Instructions sent!',
-  openTickets: 'Open Tickets',
-  support: 'Support',
-  prvChatOnly: 'Private chat only',
-  ticketClosed: 'Ticket closed',
-  links: 'Links',
-  textFirst: 'Please send a text message first.',
-  ticketClosedError: 'This ticket is closed. Please open a new one.',
-  automatedReply: 'Automated Reply',
-  automatedReplyAuthor: 'Support Team',
-  doesntHelp: "That doesn't help",
-  automatedReplySent: 'An automated reply has been sent.',
-  ticketReopened: 'Ticket reopened!',
-  yourTicketId: 'Your Ticket ID',
-  helpCommandStaffText: '/help - Staff commands reference',
-  regardsGroup: 'Regards, Support Team',
-  csatRatingRequest: 'Please rate your support experience (1-5):',
-  csatThankYou: 'Thank you for your feedback!',
-  triagePriority: 'Priority',
-  triageSummary: 'Triage Summary',
-  sentimentAlert: 'Sentiment Alert',
-  ticketAssignedTo: 'Ticket assigned to',
-  ticketUnassigned: 'Ticket unassigned',
-  assignedBy: 'Assigned by',
-  internalNote: 'Internal Note',
-  noteAddedBy: 'Note added by',
-  offlineMessage: "We're currently offline. We'll get back to you when we're available.",
-  businessHoursClosed: 'Our support hours are from {start} to {end}.',
-  escalationNotify: 'This ticket has been escalated.',
-};
 
 let parsedConfig: Record<string, unknown>;
 try {
@@ -150,9 +93,12 @@ for (const field of arrayFields) {
   }
 }
 
-// Merge language config: user values override defaults, missing keys get default fallback
-if (parsedConfig.language && typeof parsedConfig.language === 'object') {
-  cache.config.language = { ...defaultLanguage, ...parsedConfig.language } as unknown as Language;
+cache.config.language = mergeLanguage(parsedConfig.language);
+
+if (cache.config.use_llm && !cache.config.llm_knowledge) {
+  log.error(
+    'use_llm is enabled but llm_knowledge is empty: the LLM is instructed to answer only from the knowledge base and will not auto-reply.',
+  );
 }
 
 export default cache;

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -77,9 +77,19 @@ const defaultLanguage: Partial<Language> = {
   escalationNotify: 'This ticket has been escalated.',
 };
 
-const parsedConfig = YAML.parse(
-  fs.readFileSync('./config/config.yaml', 'utf8'),
-);
+let parsedConfig: Record<string, unknown>;
+try {
+  parsedConfig = YAML.parse(
+    fs.readFileSync('./config/config.yaml', 'utf8'),
+  );
+} catch (err) {
+  // Config file missing or unreadable — use empty object so defaults apply
+  parsedConfig = {};
+}
+// YAML.parse('') returns null, not undefined — normalize to empty object
+if (parsedConfig === null) {
+  parsedConfig = {};
+}
 
 // Apply defaults for missing config fields to prevent runtime errors
 cache.config = {
@@ -88,7 +98,7 @@ cache.config = {
   staffchat_parse_mode: ParseMode.MarkdownV2,
   spam_time: 5 * 60 * 1000,
   parse_mode: ParseMode.MarkdownV2,
-  language: defaultLanguage,
+  language: {} as Language,
   allow_private: false,
   direct_reply: false,
   auto_close_tickets: false,
@@ -101,6 +111,7 @@ cache.config = {
   web_server: false,
   web_server_port: 3000,
   dev_mode: false,
+  log_level: 'NONE',
   show_user_ticket: false,
   pass_start: false,
   clean_replies: false,
@@ -125,7 +136,7 @@ cache.config = {
   escalation_rules: [],
   auto_close_after_days: 0,
   ...parsedConfig,
-} as Config;
+} as unknown as Config;
 
 // Ensure array fields are actually arrays (YAML `{}` becomes empty object)
 const arrayFields = [
@@ -141,7 +152,7 @@ for (const field of arrayFields) {
 
 // Merge language config: user values override defaults, missing keys get default fallback
 if (parsedConfig.language && typeof parsedConfig.language === 'object') {
-  cache.config.language = { ...defaultLanguage, ...parsedConfig.language };
+  cache.config.language = { ...defaultLanguage, ...parsedConfig.language } as unknown as Language;
 }
 
 export default cache;

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,23 +1,147 @@
-import { Cache, Config } from './interfaces';
+import { Cache, Config, Language, Messenger, ParseMode, SocketTo } from './interfaces';
 import * as YAML from 'yaml';
 import * as fs from 'fs';
 
 const cache: Cache = {
   userId: '',
-  ticketIDs: [],
+  ticketIDs: {},
   ticketStatus: {},
   ticketSent: {},
   html: '',
   noSound: '',
   markdown: '',
-  io: {},
-  config: {
-    use_llm: false
-  } as Config,
+  io: {} as SocketTo,
+  config: {} as Config,
+  staffMembers: new Map(),
+  mutedTickets: new Set(),
+  recoveryBaseline: 0,
 };
 
-cache.config = YAML.parse(
+// Default language strings — used when config doesn't provide them
+const defaultLanguage: Partial<Language> = {
+  startCommandText: '/start - Start the bot',
+  faqCommandText: '/faq - Frequently Asked Questions',
+  helpCommandText: '/help - Get help',
+  confirmationMessage: 'Your message has been sent. We will get back to you as soon as possible.',
+  contactMessage: '',
+  blockedSpam: 'You are blocked due to spam.',
+  ticket: 'Ticket',
+  closed: 'Closed',
+  acceptedBy: 'Accepted by',
+  dear: 'Dear',
+  regards: 'Regards',
+  from: 'from',
+  language: 'Language',
+  msg_sent: 'Message sent!',
+  file_sent: 'File sent!',
+  usr_with_ticket: 'User with ticket',
+  banned: 'Banned',
+  replyPrivate: 'Reply in private chat',
+  services: 'Services',
+  customer: 'Customer',
+  msgForwarding: 'Message forwarding',
+  back: 'Back',
+  whatSubCategory: 'What sub-category?',
+  prvChatEnded: 'Private chat ended.',
+  prvChatOpened: 'Private chat opened.',
+  prvChatEnd: 'End private chat',
+  prvChatOpenedCustomer: 'Staff has opened a private chat with you.',
+  instructionsSent: 'Instructions sent!',
+  openTickets: 'Open Tickets',
+  support: 'Support',
+  prvChatOnly: 'Private chat only',
+  ticketClosed: 'Ticket closed',
+  links: 'Links',
+  textFirst: 'Please send a text message first.',
+  ticketClosedError: 'This ticket is closed. Please open a new one.',
+  automatedReply: 'Automated Reply',
+  automatedReplyAuthor: 'Support Team',
+  doesntHelp: "That doesn't help",
+  automatedReplySent: 'An automated reply has been sent.',
+  ticketReopened: 'Ticket reopened!',
+  yourTicketId: 'Your Ticket ID',
+  helpCommandStaffText: '/help - Staff commands reference',
+  regardsGroup: 'Regards, Support Team',
+  csatRatingRequest: 'Please rate your support experience (1-5):',
+  csatThankYou: 'Thank you for your feedback!',
+  triagePriority: 'Priority',
+  triageSummary: 'Triage Summary',
+  sentimentAlert: 'Sentiment Alert',
+  ticketAssignedTo: 'Ticket assigned to',
+  ticketUnassigned: 'Ticket unassigned',
+  assignedBy: 'Assigned by',
+  internalNote: 'Internal Note',
+  noteAddedBy: 'Note added by',
+  offlineMessage: "We're currently offline. We'll get back to you when we're available.",
+  businessHoursClosed: 'Our support hours are from {start} to {end}.',
+  escalationNotify: 'This ticket has been escalated.',
+};
+
+const parsedConfig = YAML.parse(
   fs.readFileSync('./config/config.yaml', 'utf8'),
 );
+
+// Apply defaults for missing config fields to prevent runtime errors
+cache.config = {
+  use_llm: false,
+  staffchat_type: Messenger.TELEGRAM,
+  staffchat_parse_mode: ParseMode.MarkdownV2,
+  spam_time: 5 * 60 * 1000,
+  parse_mode: ParseMode.MarkdownV2,
+  language: defaultLanguage,
+  allow_private: false,
+  direct_reply: false,
+  auto_close_tickets: false,
+  anonymous_tickets: false,
+  anonymous_replies: false,
+  show_auto_replied: true,
+  signal_enabled: false,
+  signal_number: '',
+  signal_host: 'signal-cli:40153',
+  web_server: false,
+  web_server_port: 3000,
+  dev_mode: false,
+  show_user_ticket: false,
+  pass_start: false,
+  clean_replies: false,
+  autoreply_confirmation: true,
+  categories: [],
+  mongodb_uri: 'mongodb://mongodb:27017/support',
+  llm_memory_depth: 10,
+  auto_triage: false,
+  sentiment_alert_threshold: 2,
+  staff_assist: false,
+  translate_enabled: false,
+  translate_target_language: 'en',
+  staff_roles: [],
+  enable_csat: false,
+  daily_summary_time: '09:00',
+  webhooks: [],
+  slack_enabled: false,
+  discord_enabled: false,
+  api_enabled: false,
+  autoreply: [],
+  canned_responses: [],
+  escalation_rules: [],
+  auto_close_after_days: 0,
+  ...parsedConfig,
+} as Config;
+
+// Ensure array fields are actually arrays (YAML `{}` becomes empty object)
+const arrayFields = [
+  'categories', 'staff_roles', 'webhooks', 'autoreply',
+  'canned_responses', 'escalation_rules',
+];
+for (const field of arrayFields) {
+  const cfg = cache.config as any;
+  if (!Array.isArray(cfg[field])) {
+    cfg[field] = [];
+  }
+}
+
+// Merge language config: user values override defaults, missing keys get default fallback
+if (parsedConfig.language && typeof parsedConfig.language === 'object') {
+  cache.config.language = { ...defaultLanguage, ...parsedConfig.language };
+}
 
 export default cache;

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -6,7 +6,7 @@ const cache: Cache = {
   userId: '',
   ticketIDs: [],
   ticketStatus: {},
-  ticketSent: [],
+  ticketSent: {},
   html: '',
   noSound: '',
   markdown: '',

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -4,34 +4,79 @@ import * as middleware from './middleware';
 import { Context } from './interfaces';
 import { ISupportee } from './db';
 import * as log from 'fancy-log'
+import * as team from './team';
+import * as analytics from './analytics';
+import * as workflows from './workflows';
+import { extractSupporteeId } from './staff';
 
-/**
- * Extracts ticket ID from the reply text.
- *
- * @param replyText - The text to extract the ticket ID from.
- * @returns The ticket ID as a string or undefined if not found.
- */
 const escapeRegex = (str: string): string => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
 /**
  * Extracts ticket ID from the reply text.
- *
- * @param replyText - The text to extract the ticket ID from.
- * @returns The ticket ID as a string or undefined if not found.
  */
 const extractTicketId = (replyText: string): string | undefined => {
-  const match = replyText.match(new RegExp(`#T(.*) ${escapeRegex(cache.config.language.from)}`));
+  const { language } = cache.config;
+  let match = replyText.match(new RegExp(`#T(.*) ${escapeRegex(language.from)}`));
+  if (!match) {
+    match = replyText.match(new RegExp(`#T(.*)\\n${escapeRegex(language.from)}`));
+  }
   return match ? match[1] : undefined;
 };
 
 /**
+ * Attempts to find a ticket from a replied message using multiple fallback strategies:
+ * 1. Regex extraction of #T ID from text
+ * 2. Extract supportee's Telegram ID from forwarded message → DB lookup by user
+ * Returns the ticket or null if all methods fail.
+ */
+async function resolveTicketFromReply(
+  replyText: string,
+  category: string | null = null,
+): Promise<{ ticket: ISupportee; ticketIdStr: string } | null> {
+  // Strategy 1: regex extraction from forwarded text
+  const extractedId = extractTicketId(replyText);
+  if (extractedId) {
+    const ticketId = parseInt(extractedId, 10);
+    if (ticketId) {
+      const ticket = await db.getTicketById(ticketId, category);
+      if (ticket) return { ticket, ticketIdStr: extractedId };
+    }
+  }
+
+  // Strategy 2: extract supportee Telegram ID from forwarded message → lookup by user
+  const supporteeId = extractSupporteeId(replyText);
+  if (supporteeId) {
+    const ticket = await db.getTicketByUserId(supporteeId, category);
+    if (ticket) return { ticket, ticketIdStr: ticket.ticketId.toString() };
+  }
+
+  return null;
+}
+
+/**
  * Display help text depending on whether the user is an admin.
- *
- * @param ctx - The bot context.
  */
 const helpCommand = (ctx: Context): void => {
   const { language, parse_mode } = cache.config;
-  const text = ctx.session.admin ? language.helpCommandStaffText : language.helpCommandText;
+  let text = ctx.session.admin ? language.helpCommandStaffText : language.helpCommandText;
+
+  // Append new staff commands to help if available
+  if (ctx.session.admin) {
+    text += `\n\n*Team & Analytics:*\n`;
+    text += `/assign <user_id> — Assign ticket to staff member\n`;
+    text += `/unassign — Unassign current ticket\n`;
+    text += `/tag <tags> — Add tags (comma-separated)\n`;
+    text += `/untag <tag> — Remove a tag\n`;
+    text += `/priority <low|normal|high|urgent> — Set priority\n`;
+    text += `/mute — Mute ticket notifications\n`;
+    text += `/unmute — Unmute ticket notifications\n`;
+    text += `/note <text> — Add internal note\n`;
+    text += `/notes — Show all internal notes\n`;
+    text += `/staff — List staff members\n`;
+    text += `/stats — Show analytics stats\n`;
+    text += `/templates — List canned responses\n`;
+  }
+
   middleware.reply(ctx, text, { parse_mode });
 };
 
@@ -44,7 +89,7 @@ const clearCommand = async (ctx: Context): Promise<void> => {
   if (!ctx.session.admin) return;
   await db.closeAll();
   // Reset the ticket caches
-  cache.ticketIDs.length = 0;
+  Object.keys(cache.ticketIDs).forEach(k => delete cache.ticketIDs[k]);
   Object.keys(cache.ticketStatus).forEach(key => delete cache.ticketStatus[key]);
   Object.keys(cache.ticketSent).forEach(key => delete cache.ticketSent[key]);
   middleware.reply(ctx, 'All tickets closed.');
@@ -55,7 +100,7 @@ const clearCommand = async (ctx: Context): Promise<void> => {
  *
  * @param ctx - The bot context.
  */
-const openCommand = (ctx: Context): void => {
+const openCommand = async (ctx: Context): Promise<void> => {
   if (!ctx.session.admin) return;
   const groups: string[] = [];
   const { categories, language } = cache.config;
@@ -65,29 +110,28 @@ const openCommand = (ctx: Context): void => {
       if (!category.subgroups) {
         if (category.group_id === ctx.chat.id) groups.push(category.name);
       } else {
-        category.subgroups.forEach((sub: { group_id: any; name: string }) => {
+        category.subgroups.forEach((sub: { group_id: unknown; name: string }) => {
           if (sub.group_id === ctx.chat.id) groups.push(sub.name);
         });
       }
     });
   }
 
-  db.open((userList: any[]) => {
-    let openTickets = '';
-    userList.forEach(ticket => {
-      if (ticket.userid != null) {
-        let ticketInfo = '';
-        const uidStr = ticket.userid.toString();
-        if (uidStr.includes('WEB')) {
-          ticketInfo = '(web)';
-        } else if (uidStr.includes('SIGNAL')) {
-          ticketInfo = '(signal)';
-        }
-        openTickets += `#T${ticket.id.toString().padStart(6, '0')} ${ticketInfo}\n`;
+  const userList = await db.open(groups);
+  let openTickets = '';
+  userList.forEach(ticket => {
+    if (ticket.userid != null) {
+      let ticketInfo = '';
+      const uidStr = ticket.userid.toString();
+      if (uidStr.includes('WEB')) {
+        ticketInfo = '(web)';
+      } else if (uidStr.includes('SIGNAL')) {
+        ticketInfo = '(signal)';
       }
-    });
-    middleware.reply(ctx, `*${language.openTickets}\n\n* ${openTickets}`);
-  }, groups);
+      openTickets += `#T${(ticket.ticketId ?? 0).toString().padStart(6, '0')} ${ticketInfo}\n`;
+    }
+  });
+  await middleware.reply(ctx, `*${language.openTickets}\n\n* ${openTickets}`);
 };
 
 /**
@@ -95,7 +139,7 @@ const openCommand = (ctx: Context): void => {
  *
  * @param ctx - The bot context.
  */
-const closeCommand = (ctx: Context): void => {
+const closeCommand = async (ctx: Context): Promise<void> => {
   if (!ctx.session.admin) return;
   const groups: string[] = [];
   const { categories, language } = cache.config;
@@ -105,7 +149,7 @@ const closeCommand = (ctx: Context): void => {
       if (!category.subgroups || category.subgroups.length === 0) {
         if (category.group_id === ctx.chat.id) groups.push(category.name);
       } else {
-        category.subgroups.forEach((sub: { group_id: any; name: string }) => {
+        category.subgroups.forEach((sub: { group_id: unknown; name: string }) => {
           if (sub.group_id === ctx.chat.id) groups.push(sub.name);
         });
       }
@@ -116,32 +160,40 @@ const closeCommand = (ctx: Context): void => {
   if (!ctx.message.reply_to_message.from.is_bot) return;
   const replyText = ctx.message.reply_to_message.text || ctx.message.reply_to_message.caption;
   if (!replyText) return;
-  const ticketId = extractTicketId(replyText);
-  if (!ticketId) return;
 
-  db.open((tickets: ISupportee[]) => {
-    if (!tickets) {
-      log.info('Close command: tickets undefined');
-      return;
+  const resolved = await resolveTicketFromReply(replyText, null);
+  if (!resolved) {
+    middleware.reply(ctx, 'Could not find ticket in the replied message.');
+    return;
+  }
+  const { ticket, ticketIdStr } = resolved;
+
+  const tickets = await db.open(groups);
+  let userId: string | null = null;
+  for (const t of tickets) {
+    if ((t.ticketId ?? 0).toString().padStart(6, '0') === ticketIdStr.padStart(6, '0')) {
+      await db.add(t.userid, 'closed', t.category ?? '', ctx.messenger);
     }
-    let userId: any = null;
-    tickets.forEach(ticket => {
-      if (ticket.id.toString().padStart(6, '0') === ticketId) {
-        db.add(ticket.userid, 'closed', ticket.category, ctx.messenger);
-      }
-      userId = ticket.userid;
-    });
-    const paddedTicket = ticketId.toString().padStart(6, '0');
-    middleware.reply(ctx, `${cache.config.language.ticket} #T${paddedTicket} ${cache.config.language.closed}`);
-    middleware.sendMessage(
+    userId = t.userid;
+  }
+
+  // Also close directly if not found in open list (ticket might already be closed)
+  if (!userId) {
+    await db.add(ticket.userid, 'closed', ticket.category ?? '', ctx.messenger);
+    userId = ticket.userid;
+  }
+  const paddedTicket = ticketIdStr.toString().padStart(6, '0');
+  await middleware.reply(ctx, `${language.ticket} #T${paddedTicket} ${language.closed}`);
+  if (userId) {
+    await middleware.sendMessage(
       userId,
       ctx.messenger,
-      `${cache.config.language.ticket} #T${paddedTicket} ${cache.config.language.closed}\n\n${cache.config.language.ticketClosed}`
-    );
+      `${language.ticket} #T${paddedTicket} ${language.closed}\n\n${language.ticketClosed}`,
+    ).catch(log.error);
     delete cache.ticketIDs[userId];
     delete cache.ticketStatus[userId];
     delete cache.ticketSent[userId];
-  }, groups);
+  }
 };
 
 /**
@@ -149,20 +201,24 @@ const closeCommand = (ctx: Context): void => {
  *
  * @param ctx - The bot context.
  */
-const banCommand = (ctx: Context): void => {
+const banCommand = async (ctx: Context): Promise<void> => {
   if (!ctx.session.admin) return;
   const replyText = ctx.message.reply_to_message.text;
   if (!replyText) return;
-  const ticketId = extractTicketId(replyText);
-  if (!ticketId) return;
-  db.getByTicketId(ticketId, (ticket: { userid: any; id: { toString: () => string } }) => {
-    db.add(ticket.userid, 'banned', '', ctx.messenger);
-    middleware.sendMessage(
-      ctx.chat.id,
-      ctx.messenger,
-      `${cache.config.language.usr_with_ticket} #T${ticketId.toString().padStart(6, '0')} ${cache.config.language.banned}`
-    );
-  });
+
+  const resolved = await resolveTicketFromReply(replyText);
+  if (!resolved) {
+    middleware.reply(ctx, 'Could not find ticket in the replied message.');
+    return;
+  }
+  const { ticket, ticketIdStr } = resolved;
+
+  await db.add(ticket.userid, 'banned', '', ctx.messenger);
+  await middleware.sendMessage(
+    ctx.chat.id,
+    ctx.messenger,
+    `${cache.config.language.usr_with_ticket} #T${ticketIdStr.toString().padStart(6, '0')} ${cache.config.language.banned}`,
+  ).catch(log.error);
 };
 
 /**
@@ -170,20 +226,24 @@ const banCommand = (ctx: Context): void => {
  *
  * @param ctx - The bot context.
  */
-const reopenCommand = (ctx: Context): void => {
+const reopenCommand = async (ctx: Context): Promise<void> => {
   if (!ctx.session.admin) return;
   const replyText = ctx.message.reply_to_message.text;
   if (!replyText) return;
-  const ticketId = extractTicketId(replyText);
-  if (!ticketId) return;
-  db.getByTicketId(ticketId, (ticket: { userid: any; id: { toString: () => string } }) => {
-    db.reopen(ticket.userid, '', ctx.messenger);
-    middleware.sendMessage(
-      ctx.chat.id,
-      ctx.messenger,
-      `${cache.config.language.usr_with_ticket} #T${ticket.id.toString().padStart(6, '0')} ${cache.config.language.ticketReopened}`
-    );
-  });
+
+  const resolved = await resolveTicketFromReply(replyText);
+  if (!resolved) {
+    middleware.reply(ctx, 'Could not find ticket in the replied message.');
+    return;
+  }
+  const { ticket, ticketIdStr } = resolved;
+
+  await db.reopen(ticket.userid, '', ctx.messenger);
+  await middleware.sendMessage(
+    ctx.chat.id,
+    ctx.messenger,
+    `${cache.config.language.usr_with_ticket} #T${ticketIdStr.toString().padStart(6, '0')} ${cache.config.language.ticketReopened}`,
+  ).catch(log.error);
 };
 
 /**
@@ -191,20 +251,284 @@ const reopenCommand = (ctx: Context): void => {
  *
  * @param ctx - The bot context.
  */
-const unbanCommand = (ctx: Context): void => {
+const unbanCommand = async (ctx: Context): Promise<void> => {
   if (!ctx.session.admin) return;
   const replyText = ctx.message.reply_to_message.text;
   if (!replyText) return;
-  const ticketId = extractTicketId(replyText);
-  if (!ticketId) return;
-  db.getByTicketId(ticketId, (ticket: { userid: any; id: { toString: () => string } }) => {
-    db.add(ticket.userid, 'closed', '', ctx.messenger);
-    middleware.sendMessage(
-      ctx.chat.id,
-      ctx.messenger,
-      `${cache.config.language.usr_with_ticket} #T${ticket.id.toString().padStart(6, '0')} unbanned`
-    );
-  });
+
+  const resolved = await resolveTicketFromReply(replyText);
+  if (!resolved) {
+    middleware.reply(ctx, 'Could not find ticket in the replied message.');
+    return;
+  }
+  const { ticket, ticketIdStr } = resolved;
+
+  await db.add(ticket.userid, 'closed', '', ctx.messenger);
+  await middleware.sendMessage(
+    ctx.chat.id,
+    ctx.messenger,
+    `${cache.config.language.usr_with_ticket} #T${ticketIdStr.toString().padStart(6, '0')} unbanned`,
+  ).catch(log.error);
+};
+
+// --- Team Collaboration Commands ---
+
+/**
+ * Assign a ticket to a staff member: /assign <telegram_id>
+ */
+const assignCommand = async (ctx: Context): Promise<void> => {
+  if (!ctx.session.admin) return;
+  const args = ctx.match?.trim();
+  if (!args) {
+    middleware.reply(ctx, 'Usage: /assign <staff_telegram_id>');
+    return;
+  }
+
+  // Check permission to assign
+  if (!team.canPerformAction(ctx.from.id.toString(), 'assign')) {
+    middleware.reply(ctx, 'You do not have permission to assign tickets.');
+    return;
+  }
+
+  const replyText = ctx.message.reply_to_message?.text || ctx.message.reply_to_message?.caption;
+  if (!replyText) {
+    middleware.reply(ctx, 'Reply to a ticket message to assign it.');
+    return;
+  }
+
+  const resolved = await resolveTicketFromReply(replyText);
+  if (!resolved) {
+    middleware.reply(ctx, 'Could not find ticket ID in the replied message.');
+    return;
+  }
+
+  await team.assignTicketCommand(ctx, args.trim(), parseInt(resolved.ticketIdStr));
+};
+
+/**
+ * Unassign a ticket: /unassign
+ */
+const unassignCommand = async (ctx: Context): Promise<void> => {
+  if (!ctx.session.admin) return;
+
+  const replyText = ctx.message.reply_to_message?.text || ctx.message.reply_to_message?.caption;
+  if (!replyText) {
+    middleware.reply(ctx, 'Reply to a ticket message to unassign it.');
+    return;
+  }
+
+  const resolved = await resolveTicketFromReply(replyText);
+  if (!resolved) {
+    middleware.reply(ctx, 'Could not find ticket ID in the replied message.');
+    return;
+  }
+
+  await team.unassignTicketCommand(ctx, parseInt(resolved.ticketIdStr));
+};
+
+/**
+ * Add tags to a ticket: /tag <tag1,tag2,...>
+ */
+const tagCommand = async (ctx: Context): Promise<void> => {
+  if (!ctx.session.admin) return;
+  const args = ctx.match?.trim();
+  if (!args) {
+    middleware.reply(ctx, 'Usage: /tag <tag1,tag2,...>');
+    return;
+  }
+
+  const replyText = ctx.message.reply_to_message?.text || ctx.message.reply_to_message?.caption;
+  if (!replyText) {
+    middleware.reply(ctx, 'Reply to a ticket message to add tags.');
+    return;
+  }
+
+  const resolved = await resolveTicketFromReply(replyText);
+  if (!resolved) {
+    middleware.reply(ctx, 'Could not find ticket ID in the replied message.');
+    return;
+  }
+
+  const tags = args.split(',').map((t: string) => t.trim()).filter(Boolean);
+  await team.addTagsCommand(ctx, parseInt(resolved.ticketIdStr), tags);
+};
+
+/**
+ * Remove a tag from a ticket: /untag <tag>
+ */
+const untagCommand = async (ctx: Context): Promise<void> => {
+  if (!ctx.session.admin) return;
+  const args = ctx.match?.trim();
+  if (!args) {
+    middleware.reply(ctx, 'Usage: /untag <tag>');
+    return;
+  }
+
+  const replyText = ctx.message.reply_to_message?.text || ctx.message.reply_to_message?.caption;
+  if (!replyText) {
+    middleware.reply(ctx, 'Reply to a ticket message to remove a tag.');
+    return;
+  }
+
+  const resolved = await resolveTicketFromReply(replyText);
+  if (!resolved) {
+    middleware.reply(ctx, 'Could not find ticket ID in the replied message.');
+    return;
+  }
+
+  await team.removeTagCommand(ctx, parseInt(resolved.ticketIdStr), args.trim());
+};
+
+/**
+ * Set priority: /priority <low|normal|high|urgent>
+ */
+const priorityCommand = async (ctx: Context): Promise<void> => {
+  if (!ctx.session.admin) return;
+  const args = ctx.match?.trim().toLowerCase() ?? '';
+  const validPriorities = ['low', 'normal', 'high', 'urgent'];
+  if (!args || !validPriorities.includes(args)) {
+    middleware.reply(ctx, `Usage: /priority <${validPriorities.join('|')}>`);
+    return;
+  }
+
+  const replyText = ctx.message.reply_to_message?.text || ctx.message.reply_to_message?.caption;
+  if (!replyText) {
+    middleware.reply(ctx, 'Reply to a ticket message to set priority.');
+    return;
+  }
+
+  const resolved = await resolveTicketFromReply(replyText);
+  if (!resolved) {
+    middleware.reply(ctx, 'Could not find ticket ID in the replied message.');
+    return;
+  }
+
+  await team.setPriorityCommand(ctx, parseInt(resolved.ticketIdStr, 10), args as import('./interfaces').TicketPriority);
+};
+
+/**
+ * Mute a ticket: /mute
+ */
+const muteCommand = async (ctx: Context): Promise<void> => {
+  if (!ctx.session.admin) return;
+
+  const replyText = ctx.message.reply_to_message?.text || ctx.message.reply_to_message?.caption;
+  if (!replyText) {
+    middleware.reply(ctx, 'Reply to a ticket message to mute it.');
+    return;
+  }
+
+  const resolved = await resolveTicketFromReply(replyText);
+  if (!resolved) {
+    middleware.reply(ctx, 'Could not find ticket ID in the replied message.');
+    return;
+  }
+
+  await team.muteTicketCommand(ctx, parseInt(resolved.ticketIdStr));
+};
+
+/**
+ * Unmute a ticket: /unmute
+ */
+const unmuteCommand = async (ctx: Context): Promise<void> => {
+  if (!ctx.session.admin) return;
+
+  const replyText = ctx.message.reply_to_message?.text || ctx.message.reply_to_message?.caption;
+  if (!replyText) {
+    middleware.reply(ctx, 'Reply to a ticket message to unmute it.');
+    return;
+  }
+
+  const resolved = await resolveTicketFromReply(replyText);
+  if (!resolved) {
+    middleware.reply(ctx, 'Could not find ticket ID in the replied message.');
+    return;
+  }
+
+  await team.unmuteTicketCommand(ctx, parseInt(resolved.ticketIdStr));
+};
+
+/**
+ * Add internal note: /note <text>
+ */
+const noteCommand = async (ctx: Context): Promise<void> => {
+  if (!ctx.session.admin) return;
+  const args = ctx.match?.trim();
+  if (!args) {
+    middleware.reply(ctx, 'Usage: /note <internal note text>');
+    return;
+  }
+
+  const replyText = ctx.message.reply_to_message?.text || ctx.message.reply_to_message?.caption;
+  if (!replyText) {
+    middleware.reply(ctx, 'Reply to a ticket message to add an internal note.');
+    return;
+  }
+
+  const resolved = await resolveTicketFromReply(replyText);
+  if (!resolved) {
+    middleware.reply(ctx, 'Could not find ticket ID in the replied message.');
+    return;
+  }
+
+  await team.addInternalNoteCommand(ctx, parseInt(resolved.ticketIdStr), args);
+};
+
+/**
+ * Show internal notes: /notes
+ */
+const notesCommand = async (ctx: Context): Promise<void> => {
+  if (!ctx.session.admin) return;
+
+  const replyText = ctx.message.reply_to_message?.text || ctx.message.reply_to_message?.caption;
+  if (!replyText) {
+    middleware.reply(ctx, 'Reply to a ticket message to view its internal notes.');
+    return;
+  }
+
+  const resolved = await resolveTicketFromReply(replyText);
+  if (!resolved) {
+    middleware.reply(ctx, 'Could not find ticket ID in the replied message.');
+    return;
+  }
+
+  await team.showNotesCommand(ctx, parseInt(resolved.ticketIdStr));
+};
+
+/**
+ * List staff members: /staff
+ */
+const listStaffCommand = async (ctx: Context): Promise<void> => {
+  if (!ctx.session.admin) return;
+  await team.listStaffCommand(ctx);
+};
+
+// --- Analytics Commands ---
+
+/**
+ * Show analytics stats: /stats
+ */
+const statsCommand = async (ctx: Context): Promise<void> => {
+  if (!ctx.session.admin) return;
+
+  // Check permission to view analytics
+  if (!team.canPerformAction(ctx.from.id.toString(), 'view_analytics')) {
+    middleware.reply(ctx, 'You do not have permission to view analytics.');
+    return;
+  }
+
+  await analytics.showStatsCommand(ctx);
+};
+
+// --- Workflow Commands ---
+
+/**
+ * List canned responses: /templates
+ */
+const templatesCommand = (ctx: Context): void => {
+  if (!ctx.session.admin) return;
+  const output = workflows.listCannedResponses();
+  middleware.reply(ctx, output, { parse_mode: cache.config.parse_mode });
 };
 
 export {
@@ -215,4 +539,19 @@ export {
   clearCommand,
   reopenCommand,
   helpCommand,
+  // Team collaboration commands
+  assignCommand,
+  unassignCommand,
+  tagCommand,
+  untagCommand,
+  priorityCommand,
+  muteCommand,
+  unmuteCommand,
+  noteCommand,
+  notesCommand,
+  listStaffCommand,
+  // Analytics commands
+  statsCommand,
+  // Workflow commands
+  templatesCommand,
 };

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -3,7 +3,7 @@ import cache from './cache';
 import * as middleware from './middleware';
 import { Context } from './interfaces';
 import { ISupportee } from './db';
-import * as log from 'fancy-log'
+import * as log from './logger'
 import * as team from './team';
 import * as analytics from './analytics';
 import * as workflows from './workflows';

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -11,8 +11,16 @@ import * as log from 'fancy-log'
  * @param replyText - The text to extract the ticket ID from.
  * @returns The ticket ID as a string or undefined if not found.
  */
+const escapeRegex = (str: string): string => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+/**
+ * Extracts ticket ID from the reply text.
+ *
+ * @param replyText - The text to extract the ticket ID from.
+ * @returns The ticket ID as a string or undefined if not found.
+ */
 const extractTicketId = (replyText: string): string | undefined => {
-  const match = replyText.match(new RegExp(`#T(.*) ${cache.config.language.from}`));
+  const match = replyText.match(new RegExp(`#T(.*) ${escapeRegex(cache.config.language.from)}`));
   return match ? match[1] : undefined;
 };
 
@@ -32,13 +40,13 @@ const helpCommand = (ctx: Context): void => {
  *
  * @param ctx - The bot context.
  */
-const clearCommand = (ctx: Context): void => {
+const clearCommand = async (ctx: Context): Promise<void> => {
   if (!ctx.session.admin) return;
-  db.closeAll();
-  // Reset the ticket arrays
+  await db.closeAll();
+  // Reset the ticket caches
   cache.ticketIDs.length = 0;
-  cache.ticketStatus.length = 0;
-  cache.ticketSent.length = 0;
+  Object.keys(cache.ticketStatus).forEach(key => delete cache.ticketStatus[key]);
+  Object.keys(cache.ticketSent).forEach(key => delete cache.ticketSent[key]);
   middleware.reply(ctx, 'All tickets closed.');
 };
 
@@ -55,10 +63,10 @@ const openCommand = (ctx: Context): void => {
   if (categories && categories.length > 0) {
     categories.forEach(category => {
       if (!category.subgroups) {
-        if (category.group_id == ctx.chat.id) groups.push(category.name);
+        if (category.group_id === ctx.chat.id) groups.push(category.name);
       } else {
         category.subgroups.forEach((sub: { group_id: any; name: string }) => {
-          if (sub.group_id == ctx.chat.id) groups.push(sub.name);
+          if (sub.group_id === ctx.chat.id) groups.push(sub.name);
         });
       }
     });
@@ -95,10 +103,10 @@ const closeCommand = (ctx: Context): void => {
   if (categories) {
     categories.forEach(category => {
       if (!category.subgroups || category.subgroups.length === 0) {
-        if (category.group_id == ctx.chat.id) groups.push(category.name);
+        if (category.group_id === ctx.chat.id) groups.push(category.name);
       } else {
         category.subgroups.forEach((sub: { group_id: any; name: string }) => {
-          if (sub.group_id == ctx.chat.id) groups.push(sub.name);
+          if (sub.group_id === ctx.chat.id) groups.push(sub.name);
         });
       }
     });

--- a/src/db.ts
+++ b/src/db.ts
@@ -60,12 +60,16 @@ export const check = async (
   category: any,
   callback: (result: any) => void
 ) => {
-  const query = {
-    $or: [{ userid: userid }, { ticketId: userid }],
-    ...(category && { category }),
-  };
-  const result = await Supportee.find(query);
-  callback(result);
+  try {
+    const query = {
+      $or: [{ userid: userid }, { ticketId: userid }],
+      ...(category && { category }),
+    };
+    const result = await Supportee.find(query);
+    callback(result);
+  } catch (err) {
+    log.error('DB check error:', err);
+  }
 };
 
 export async function getTicketById(
@@ -106,9 +110,13 @@ export const getByTicketId = async (
   ticketId: string,
   callback: (ticket: any) => void
 ) => {
-  const query = { $or: [{ ticketId: ticketId }] };
-  const result = await Supportee.findOne(query);
-  callback(result);
+  try {
+    const query = { $or: [{ ticketId: ticketId }] };
+    const result = await Supportee.findOne(query);
+    callback(result);
+  } catch (err) {
+    log.error('DB getByTicketId error:', err);
+  }
 };
 
 export const checkBan = async (
@@ -116,13 +124,17 @@ export const checkBan = async (
   messenger: string,
   callback: (ticket: any) => void
 ) => {
-  const query = {
-    messenger,
-    $or: [{ userid: userid }],
-    status: 'banned',
-  };
-  const result = await Supportee.findOne(query);
-  callback(result);
+  try {
+    const query = {
+      messenger,
+      $or: [{ userid: userid }],
+      status: 'banned',
+    };
+    const result = await Supportee.findOne(query);
+    callback(result);
+  } catch (err) {
+    log.error('DB checkBan error:', err);
+  }
 };
 
 export const closeAll = async () => {
@@ -201,12 +213,16 @@ export const open = async (
   callback: Function,
   category: string[],
 ) => {
-  const query = {
-    status: 'open',
-    ...(category.length > 0
-      ? { category: { $in: category } }
-      : { category: null }),
-  };
-  const result = await Supportee.find(query);
-  callback(result);
+  try {
+    const query = {
+      status: 'open',
+      ...(category.length > 0
+        ? { category: { $in: category } }
+        : { category: null }),
+    };
+    const result = await Supportee.find(query);
+    callback(result);
+  } catch (err) {
+    log.error('DB open error:', err);
+  }
 };

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,6 +1,6 @@
 import mongoose from 'mongoose';
 import cache from './cache';
-import { Messenger } from './interfaces';
+import { Messenger, TicketPriority } from './interfaces';
 import * as log from 'fancy-log'
 
 const MONGO_URI = cache.config.mongodb_uri || process.env.MONGO_URI || 'mongodb://localhost:27017/support';
@@ -15,6 +15,17 @@ export interface ISupportee extends mongoose.Document {
   messenger: Messenger;
   status: string;
   category: string | null;
+  // Team collaboration fields
+  assigned_to: string | null;
+  tags: string[];
+  priority: TicketPriority;
+  // AI triage fields
+  triage_category: string | null;
+  triage_summary: string | null;
+  sentiment_score: number | null;
+  // Analytics fields
+  first_response_at: Date | null;
+  closed_at: Date | null;
 }
 
 export const SupporteeSchema = new mongoose.Schema<ISupportee>({
@@ -25,9 +36,73 @@ export const SupporteeSchema = new mongoose.Schema<ISupportee>({
   messenger: { type: String, required: true },
   status: { type: String, default: 'open' },
   category: { type: String, default: null },
+  assigned_to: { type: String, default: null },
+  tags: { type: [String], default: [] },
+  priority: { type: String, enum: ['low', 'normal', 'high', 'urgent'], default: 'normal' as TicketPriority },
+  triage_category: { type: String, default: null },
+  triage_summary: { type: String, default: null },
+  sentiment_score: { type: Number, default: null },
+  first_response_at: { type: Date, default: null },
+  closed_at: { type: Date, default: null },
 });
 
 const Supportee = mongoose.model(collectionName, SupporteeSchema);
+
+export { Supportee };
+
+// --- New collections for team collaboration & analytics ---
+
+export interface ITicketMessage extends mongoose.Document {
+  ticketId: number;
+  sender: 'user' | 'staff' | 'ai';
+  sender_id: string;
+  text: string;
+  timestamp: Date;
+}
+
+const TicketMessageSchema = new mongoose.Schema<ITicketMessage>({
+  ticketId: { type: Number, required: true },
+  sender: { type: String, enum: ['user', 'staff', 'ai'], required: true },
+  sender_id: { type: String, default: '' },
+  text: { type: String, required: true },
+  timestamp: { type: Date, default: Date.now },
+});
+
+const TicketMessage = mongoose.model('TicketMessage', TicketMessageSchema);
+
+export interface IAnalyticsEvent extends mongoose.Document {
+  type: string;
+  ticketId: number;
+  timestamp: Date;
+  agent_id: string | null;
+  metadata: Record<string, any>;
+}
+
+const AnalyticsEventSchema = new mongoose.Schema<IAnalyticsEvent>({
+  type: { type: String, required: true },
+  ticketId: { type: Number, required: true },
+  timestamp: { type: Date, default: Date.now },
+  agent_id: { type: String, default: null },
+  metadata: { type: mongoose.Schema.Types.Mixed, default: {} },
+});
+
+const AnalyticsEvent = mongoose.model('AnalyticsEvent', AnalyticsEventSchema);
+
+export interface IInternalNote extends mongoose.Document {
+  ticketId: number;
+  author_id: string;
+  text: string;
+  timestamp: Date;
+}
+
+const InternalNoteSchema = new mongoose.Schema<IInternalNote>({
+  ticketId: { type: Number, required: true },
+  author_id: { type: String, required: true },
+  text: { type: String, required: true },
+  timestamp: { type: Date, default: Date.now },
+});
+
+const InternalNote = mongoose.model('InternalNote', InternalNoteSchema);
 
 export async function connect() {
   mongoose.connection.on('open', () => {
@@ -52,25 +127,27 @@ export const getNextTicketId = async () => {
   const lastEntry = await Supportee.findOne()
     .sort({ ticketId: -1 })
     .select('ticketId');
-  return lastEntry ? lastEntry.ticketId + 1 : 1; // Start from 1 if no entries
+  const dbMax = lastEntry ? lastEntry.ticketId : 0;
+  // Use the higher of DB max or recovery baseline (from chat history scan) to prevent collisions on DB loss
+  const baseline = Math.max(dbMax, cache.recoveryBaseline);
+  return baseline + 1;
 };
 
-export const check = async (
-  userid: any,
-  category: any,
-  callback: (result: any) => void
-) => {
+export async function check(
+  userid: string | number,
+  category?: string | null,
+): Promise<ISupportee[]> {
   try {
-    const query = {
-      $or: [{ userid: userid }, { ticketId: userid }],
-      ...(category && { category }),
+    const query: Record<string, unknown> = {
+      $or: [{ userid: String(userid) }, { ticketId: userid }],
     };
-    const result = await Supportee.find(query);
-    callback(result);
+    if (category) query.category = category;
+    return await Supportee.find(query).lean();
   } catch (err) {
     log.error('DB check error:', err);
+    return [];
   }
-};
+}
 
 export async function getTicketById(
   ticketId: string | number,
@@ -106,36 +183,34 @@ export async function getTicketByUserId (
   return result;
 };
 
-export const getByTicketId = async (
+export async function getByTicketId(
   ticketId: string,
-  callback: (ticket: any) => void
-) => {
+): Promise<ISupportee | null> {
   try {
-    const query = { $or: [{ ticketId: ticketId }] };
-    const result = await Supportee.findOne(query);
-    callback(result);
+    const query = { $or: [{ ticketId }] };
+    return await Supportee.findOne(query) as ISupportee | null;
   } catch (err) {
     log.error('DB getByTicketId error:', err);
+    return null;
   }
-};
+}
 
-export const checkBan = async (
-  userid: any,
+export async function checkBan(
+  userid: string | number,
   messenger: string,
-  callback: (ticket: any) => void
-) => {
+): Promise<ISupportee | null> {
   try {
     const query = {
       messenger,
-      $or: [{ userid: userid }],
+      $or: [{ userid: String(userid) }],
       status: 'banned',
     };
-    const result = await Supportee.findOne(query);
-    callback(result);
+    return await Supportee.findOne(query) as ISupportee | null;
   } catch (err) {
     log.error('DB checkBan error:', err);
+    return null;
   }
-};
+}
 
 export const closeAll = async () => {
   await Supportee.updateMany({}, { $set: { status: 'closed' } });
@@ -206,23 +281,276 @@ export const add = async (
       { upsert: true }
     );
   }
-  return result?.modifiedCount || 0;
+  const writeResult = result as { modifiedCount?: number } | null | undefined;
+  return writeResult?.modifiedCount ?? 0;
 };
 
-export const open = async (
-  callback: Function,
-  category: string[],
-) => {
+export async function open(
+  category: string[] = [],
+): Promise<ISupportee[]> {
   try {
-    const query = {
+    const query: Record<string, unknown> = {
       status: 'open',
-      ...(category.length > 0
-        ? { category: { $in: category } }
-        : { category: null }),
     };
-    const result = await Supportee.find(query);
-    callback(result);
+    if (category.length > 0) {
+      query.category = { $in: category };
+    } else {
+      query.category = null;
+    }
+    return await Supportee.find(query).lean();
   } catch (err) {
     log.error('DB open error:', err);
+    return [];
   }
-};
+}
+
+// --- Ticket Message methods (conversation memory) ---
+
+export async function addTicketMessage(
+  ticketId: number,
+  sender: 'user' | 'staff' | 'ai',
+  sender_id: string,
+  text: string,
+): Promise<void> {
+  try {
+    const msg = new TicketMessage({ ticketId, sender, sender_id, text });
+    await msg.save();
+    // Keep only last N messages per ticket (configurable)
+    const depth = cache.config.llm_memory_depth || 10;
+    const excess = await TicketMessage.find({ ticketId })
+      .sort({ timestamp: -1 })
+      .skip(depth);
+    if (excess.length > 0) {
+      const ids = excess.map((m) => m._id);
+      await TicketMessage.deleteMany({ _id: { $in: ids } });
+    }
+  } catch (err) {
+    log.error('DB addTicketMessage error:', err);
+  }
+}
+
+export async function getConversationHistory(
+  ticketId: number,
+  depth?: number,
+): Promise<ITicketMessage[]> {
+  try {
+    const limit = depth || (cache.config.llm_memory_depth ?? 10);
+    return await TicketMessage.find({ ticketId })
+      .sort({ timestamp: -1 })
+      .limit(limit)
+      .lean();
+  } catch (err) {
+    log.error('DB getConversationHistory error:', err);
+    return [];
+  }
+}
+
+// --- Analytics Event methods ---
+
+export async function recordAnalyticsEvent(
+  type: string,
+  ticketId: number,
+  agent_id: string | null = null,
+  metadata: Record<string, any> = {},
+): Promise<void> {
+  try {
+    const event = new AnalyticsEvent({ type, ticketId, agent_id, metadata });
+    await event.save();
+  } catch (err) {
+    log.error('DB recordAnalyticsEvent error:', err);
+  }
+}
+
+export async function getAnalyticsEvents(
+  type?: string,
+  startDate?: Date,
+  endDate?: Date,
+): Promise<IAnalyticsEvent[]> {
+  try {
+    const query: Record<string, any> = {};
+    if (type) query.type = type;
+    if (startDate || endDate) {
+      query.timestamp = {};
+      if (startDate) query.timestamp.$gte = startDate;
+      if (endDate) query.timestamp.$lte = endDate;
+    }
+    return await AnalyticsEvent.find(query).sort({ timestamp: -1 }).lean();
+  } catch (err) {
+    log.error('DB getAnalyticsEvents error:', err);
+    return [];
+  }
+}
+
+// --- Internal Note methods ---
+
+export async function addInternalNote(
+  ticketId: number,
+  author_id: string,
+  text: string,
+): Promise<void> {
+  try {
+    const note = new InternalNote({ ticketId, author_id, text });
+    await note.save();
+  } catch (err) {
+    log.error('DB addInternalNote error:', err);
+  }
+}
+
+export async function getInternalNotes(
+  ticketId: number,
+): Promise<IInternalNote[]> {
+  try {
+    return await InternalNote.find({ ticketId })
+      .sort({ timestamp: -1 })
+      .lean();
+  } catch (err) {
+    log.error('DB getInternalNotes error:', err);
+    return [];
+  }
+}
+
+// --- Ticket assignment methods ---
+
+export async function assignTicket(
+  ticketId: number,
+  agent_telegram_id: string,
+): Promise<void> {
+  try {
+    await Supportee.findOneAndUpdate(
+      { ticketId },
+      { $set: { assigned_to: agent_telegram_id } },
+    );
+  } catch (err) {
+    log.error('DB assignTicket error:', err);
+  }
+}
+
+export async function unassignTicket(ticketId: number): Promise<void> {
+  try {
+    await Supportee.findOneAndUpdate(
+      { ticketId },
+      { $set: { assigned_to: null } },
+    );
+  } catch (err) {
+    log.error('DB unassignTicket error:', err);
+  }
+}
+
+// --- Tag methods ---
+
+export async function addTags(ticketId: number, tags: string[]): Promise<void> {
+  try {
+    await Supportee.findOneAndUpdate(
+      { ticketId },
+      { $addToSet: { tags: { $each: tags } } },
+    );
+  } catch (err) {
+    log.error('DB addTags error:', err);
+  }
+}
+
+export async function removeTag(ticketId: number, tag: string): Promise<void> {
+  try {
+    await Supportee.findOneAndUpdate(
+      { ticketId },
+      { $pull: { tags: tag } },
+    );
+  } catch (err) {
+    log.error('DB removeTag error:', err);
+  }
+}
+
+// --- Priority methods ---
+
+export async function setPriority(
+  ticketId: number,
+  priority: TicketPriority,
+): Promise<void> {
+  try {
+    await Supportee.findOneAndUpdate(
+      { ticketId },
+      { $set: { priority } },
+    );
+  } catch (err) {
+    log.error('DB setPriority error:', err);
+  }
+}
+
+// --- Triage methods ---
+
+export async function setTriageInfo(
+  ticketId: number,
+  category: string | null,
+  summary: string | null,
+  sentimentScore: number | null,
+): Promise<void> {
+  try {
+    await Supportee.findOneAndUpdate(
+      { ticketId },
+      { $set: { triage_category: category, triage_summary: summary, sentiment_score: sentimentScore } },
+    );
+  } catch (err) {
+    log.error('DB setTriageInfo error:', err);
+  }
+}
+
+// --- Analytics timestamp methods ---
+
+export async function setFirstResponseAt(ticketId: number): Promise<void> {
+  try {
+    await Supportee.findOneAndUpdate(
+      { ticketId, first_response_at: null },
+      { $set: { first_response_at: new Date() } },
+    );
+  } catch (err) {
+    log.error('DB setFirstResponseAt error:', err);
+  }
+}
+
+export async function setClosedAt(ticketId: number): Promise<void> {
+  try {
+    await Supportee.findOneAndUpdate(
+      { ticketId },
+      { $set: { closed_at: new Date() } },
+    );
+  } catch (err) {
+    log.error('DB setClosedAt error:', err);
+  }
+}
+
+// --- Open tickets with tag filter ---
+
+export async function openByTag(
+  tag: string,
+  category: string[] = [],
+): Promise<ISupportee[]> {
+  try {
+    const query: Record<string, unknown> = {
+      status: 'open',
+      tags: tag,
+    };
+    if (category.length > 0) {
+      query.category = { $in: category };
+    } else {
+      query.category = null;
+    }
+    return await Supportee.find(query).lean();
+  } catch (err) {
+    log.error('DB openByTag error:', err);
+    return [];
+  }
+}
+
+// --- CSAT methods ---
+
+export async function recordCSAT(
+  ticketId: number,
+  rating: number,
+  comment: string = '',
+): Promise<void> {
+  await recordAnalyticsEvent('csat.rated', ticketId, null, { rating, comment });
+}
+
+// --- Export models for use in other modules ---
+
+export { TicketMessage, AnalyticsEvent, InternalNote };

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,11 +1,21 @@
 import mongoose from 'mongoose';
 import cache from './cache';
 import { Messenger, TicketPriority } from './interfaces';
-import * as log from 'fancy-log'
+import * as log from './logger'
 
-const MONGO_URI = cache.config.mongodb_uri || process.env.MONGO_URI || 'mongodb://localhost:27017/support';
-const botTokenSuffix = cache.config.bot_token.slice(-5);
-const collectionName = `bot_${cache.config.owner_id}_${botTokenSuffix}`;
+// Lazy config accessors — defer reading cache.config until runtime
+// to avoid circular module initialization issues (index → migrate → db → cache)
+function getMongoUri(): string {
+  return cache.config?.mongodb_uri || process.env.MONGO_URI || 'mongodb://localhost:27017/support';
+}
+
+function getBotTokenSuffix(): string {
+  return cache.config?.bot_token?.slice(-5) || '';
+}
+
+function getCollectionName(): string {
+  return `bot_${cache.config?.owner_id}_${getBotTokenSuffix()}`;
+}
 
 export interface ISupportee extends mongoose.Document {
   ticketId: number;
@@ -46,7 +56,7 @@ export const SupporteeSchema = new mongoose.Schema<ISupportee>({
   closed_at: { type: Date, default: null },
 });
 
-const Supportee = mongoose.model(collectionName, SupporteeSchema);
+const Supportee = mongoose.model(getCollectionName(), SupporteeSchema);
 
 export { Supportee };
 
@@ -114,7 +124,7 @@ export async function connect() {
     process.exit(1);
   });
 
-  const connection = await mongoose.connect(MONGO_URI, {
+  const connection = await mongoose.connect(getMongoUri(), {
     serverSelectionTimeoutMS: 5000,
   });
 

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,5 +1,4 @@
 import * as fs from 'fs';
-import * as util from 'util';
 import cache from './cache';
 import * as middleware from './middleware';
 import * as log from 'fancy-log'
@@ -53,22 +52,6 @@ function init(logs = true) {
     waiting = true;
     currentErrors++;
   };
-
-  // Overload log.info to write to file when logging is enabled
-  // log.info = (d: any) => {
-  //   if (logs) {
-  //     const formatted = util.format(d);
-  //     logStdout.write(formatted + '\n');
-  //     fs.appendFile(
-  //       debugFile,
-  //       `${new Date()}: ${formatted}\n`,
-  //       'utf8',
-  //       err => {
-  //         if (err) throw err;
-  //       }
-  //     );
-  //   }
-  // };
 
   // Catch uncaught exceptions to log them and notify staff
   process.on('uncaughtException', (err) => {

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,17 +1,13 @@
-import * as fs from 'fs';
 import cache from './cache';
 import * as middleware from './middleware';
-import * as log from 'fancy-log'
-
-const debugFile = './config/debug.log';
-const logStdout = process.stdout;
+import * as log from './logger'
 
 /**
  * Initializes error logging and global exception handlers.
  *
  * @param logs - Whether to log to file (default true).
  */
-function init(logs = true) {
+function init(logs: boolean) {
   // Rate limiting state — tracks recent errors to avoid spamming staff chat
   let currentErrors = 0;
   let lastErrorReset: number = Date.now();
@@ -32,14 +28,6 @@ function init(logs = true) {
   };
 
   /**
-   * Writes error details to the debug log file.
-   */
-  const writeDebugLog = (error: unknown): void => {
-    const message = `${new Date().toISOString()}: ${error instanceof Error ? error.stack : String(error)}\n`;
-    fs.appendFileSync(debugFile, message, 'utf8');
-  };
-
-  /**
    * Sends a notification to the staff chat about the error.
    */
   const notifyStaff = (errorMessage: string): void => {
@@ -56,7 +44,6 @@ function init(logs = true) {
   process.on('uncaughtException', (err: unknown) => {
     const error = err instanceof Error ? err : new Error(String(err));
     log.info('=== UNHANDLED ERROR ===');
-    writeDebugLog(error);
     log.error(`${new Date()}: Unhandled exception:`, error);
     notifyStaff(`An uncaught error occurred. Please report this to your admin:\n\n${error.message}`);
     process.exit(1);
@@ -66,8 +53,8 @@ function init(logs = true) {
   process.on('unhandledRejection', (reason: unknown) => {
     const errorMessage = reason instanceof Error ? reason.stack : String(reason);
     log.info('=== UNHANDLED REJECTION ===');
-    writeDebugLog(errorMessage);
-    console.error(`${new Date()}: Unhandled rejection:`, errorMessage);
+    log.error(`Unhandled rejection:`, errorMessage);
+    console.error(`[${new Date().toISOString()}] Unhandled rejection:`, errorMessage);
     notifyStaff(`An unhandled promise rejection occurred. Please report this to your admin:\n\n${errorMessage}`);
   });
 }

--- a/src/error.ts
+++ b/src/error.ts
@@ -12,79 +12,63 @@ const logStdout = process.stdout;
  * @param logs - Whether to log to file (default true).
  */
 function init(logs = true) {
-  // Rate limiting variables
+  // Rate limiting state — tracks recent errors to avoid spamming staff chat
   let currentErrors = 0;
-  let lastErrors = 0;
-  let waiting = false;
-  let waitingLast = false;
+  let lastErrorReset: number = Date.now();
 
   /**
-   * Sleeps for the specified number of seconds.
-   *
-   * @param seconds - Number of seconds to sleep.
-   * @returns A promise that resolves after the delay.
+   * Checks if we should suppress notifications due to error flood.
+   * Returns true when in normal operation (safe to notify).
    */
-  const sleep = (seconds: number) =>
-    new Promise(resolve => setTimeout(resolve, seconds * 1000));
-
-  /**
-   * Applies rate limiting by delaying execution when errors occur too frequently.
-   */
-  const rateLimit = () => {
-    if (currentErrors > 3) {
-      // "Synchronous" wait (note: not truly synchronous in Node)
-      sleep(5 * lastErrors);
+  const shouldNotify = (): boolean => {
+    // Reset counter every 30 seconds
+    if (Date.now() - lastErrorReset > 30_000) {
       currentErrors = 0;
-      lastErrors++;
+      lastErrorReset = Date.now();
     }
-    if (!waiting) {
-      setTimeout(() => {
-        currentErrors = 0;
-        waiting = false;
-      }, 3000);
-    }
-    if (!waitingLast) {
-      setTimeout(() => {
-        currentErrors = 0;
-        waitingLast = false;
-      }, 30000);
-    }
-    waiting = true;
     currentErrors++;
+    // Only notify on the first error in a window, then suppress to avoid spam
+    return currentErrors <= 1 || currentErrors % 5 === 0;
   };
 
-  // Catch uncaught exceptions to log them and notify staff
-  process.on('uncaughtException', (err) => {
-    rateLimit();
-    log.info('=== UNHANDLED ERROR ===');
-    fs.appendFile(debugFile, err.stack + '\n', 'utf8', appendErr => {
-      if (appendErr) throw appendErr;
-    });
-    log.error(`${new Date()}: Error: `, err);
+  /**
+   * Writes error details to the debug log file.
+   */
+  const writeDebugLog = (error: unknown): void => {
+    const message = `${new Date().toISOString()}: ${error instanceof Error ? error.stack : String(error)}\n`;
+    fs.appendFileSync(debugFile, message, 'utf8');
+  };
+
+  /**
+   * Sends a notification to the staff chat about the error.
+   */
+  const notifyStaff = (errorMessage: string): void => {
+    if (!shouldNotify()) return;
     middleware.sendMessage(
       cache.config.staffchat_id,
       cache.config.staffchat_type,
-      `An error occurred, please report this to your admin: \n\n ${err}`,
-      {}
-    );
+      errorMessage,
+      {},
+    ).catch(log.error);
+  };
+
+  // Catch uncaught exceptions to log them and notify staff
+  process.on('uncaughtException', (err: unknown) => {
+    const error = err instanceof Error ? err : new Error(String(err));
+    log.info('=== UNHANDLED ERROR ===');
+    writeDebugLog(error);
+    log.error(`${new Date()}: Unhandled exception:`, error);
+    notifyStaff(`An uncaught error occurred. Please report this to your admin:\n\n${error.message}`);
     process.exit(1);
   });
 
   // Catch unhandled promise rejections to log them and notify staff if necessary
-  process.on('unhandledRejection', (err: any) => {
-    rateLimit();
+  process.on('unhandledRejection', (reason: unknown) => {
+    const errorMessage = reason instanceof Error ? reason.stack : String(reason);
     log.info('=== UNHANDLED REJECTION ===');
-    fs.appendFile(debugFile, err + '\n', 'utf8', appendErr => {
-      if (appendErr) throw appendErr;
-    });
-    console.dir(`${new Date()}: ${err.stack}`);
-    if (currentErrors === 0) {
-      middleware.sendMessage(
-        cache.config.staffchat_id,
-        cache.config.staffchat_type,
-        `An error occurred, please report this to your admin: \n\n ${err}`
-      );
-    }
+    writeDebugLog(errorMessage);
+    console.error(`${new Date()}: Unhandled rejection:`, errorMessage);
+    notifyStaff(`An unhandled promise rejection occurred. Please report this to your admin:\n\n${errorMessage}`);
   });
 }
 

--- a/src/files.ts
+++ b/src/files.ts
@@ -1,8 +1,10 @@
 import * as db from './db';
 import cache from './cache';
-import * as middleware from './middleware';
+import { buildInlineKeyboard, reply, sendMessage } from './middleware';
 import { Addon, Context, ModeData } from './interfaces';
 import { ISupportee } from './db';
+
+const escapeRegex = (str: string): string => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
 /**
  * Generates the reply markup for a private reply.
@@ -64,9 +66,9 @@ async function fileHandler(type: string, bot: Addon, ctx: Context) {
   const ticket = await db.getTicketByUserId(userid, session.groupCategory);
   if (!ticket) {
     if (session.admin && userInfo === undefined) {
-      middleware.reply(ctx, config.language.ticketClosedError);
+      reply(ctx, config.language.ticketClosedError);
     } else {
-      middleware.reply(ctx, config.language.textFirst);
+      reply(ctx, config.language.textFirst);
     }
     return;
   }
@@ -90,79 +92,45 @@ async function fileHandler(type: string, bot: Addon, ctx: Context) {
   };
 
   // Send the file based on its type
-  var messageId = null;
+  let messageId: string | null | undefined = undefined;
+  const shouldForwardToGroup = (
+    session.group !== '' &&
+    session.group !== config.staffchat_id &&
+    Object.keys(session.modeData).length > 0
+  );
+
   switch (type) {
     case 'document':
-      messageId = await bot.sendDocument(receiverId, fileId, commonOptions);
-      if (
-        session.group !== '' &&
-        session.group !== config.staffchat_id &&
-        JSON.stringify(session.modeData) !== JSON.stringify({})
-      ) {
+      messageId = (await bot.sendDocument(receiverId, fileId, commonOptions)) as string | null;
+      if (shouldForwardToGroup) {
         bot.sendDocument(session.group, fileId, {
           caption: captionText,
-          reply_markup: {
-            html: '',
-            inline_keyboard: [
-              [
-                {
-                  text: config.language.replyPrivate,
-                  callback_data: `${ctx.from.id}---${message.from.first_name}---${session.groupCategory}---${ticket.id}`,
-                },
-              ],
-            ],
-          },
+          reply_markup: buildInlineKeyboard(ctx.from.id, message.from.first_name, session.groupCategory, ticket.id),
         });
-      } 
+      }
       break;
     case 'photo':
-      messageId = await bot.sendPhoto(receiverId, fileId, commonOptions);
-      if (
-        session.group !== '' &&
-        session.group !== config.staffchat_id &&
-        JSON.stringify(session.modeData) !== JSON.stringify({})
-      ) {
+      messageId = (await bot.sendPhoto(receiverId, fileId, commonOptions)) as string | null;
+      if (shouldForwardToGroup) {
         bot.sendPhoto(session.group, fileId, {
           caption: captionText,
-          reply_markup: {
-            html: '',
-            inline_keyboard: [
-              [
-                {
-                  text: config.language.replyPrivate,
-                  callback_data: `${ctx.from.id}---${message.from.first_name}---${session.groupCategory}---${ticket.id}`,
-                },
-              ],
-            ],
-          },
+          reply_markup: buildInlineKeyboard(ctx.from.id, message.from.first_name, session.groupCategory, ticket.id),
         });
       }
       break;
     case 'video':
-      messageId = await bot.sendVideo(receiverId, fileId, commonOptions);
-      if (
-        session.group !== '' &&
-        session.group !== config.staffchat_id &&
-        JSON.stringify(session.modeData) !== JSON.stringify({})
-      ) {
+      messageId = (await bot.sendVideo(receiverId, fileId, commonOptions)) as string | null;
+      if (shouldForwardToGroup) {
         bot.sendVideo(session.group, fileId, {
           caption: captionText,
-          reply_markup: {
-            html: '',
-            inline_keyboard: [
-              [
-                {
-                  text: config.language.replyPrivate,
-                  callback_data: `${ctx.from.id}---${message.from.first_name}---${session.groupCategory}---${ticket.id}`,
-                },
-              ],
-            ],
-          },
+          reply_markup: buildInlineKeyboard(ctx.from.id, message.from.first_name, session.groupCategory, ticket.id),
         });
       }
       break;
   }
-  db.addIdAndName(ticket.ticketId, messageId, ctx.message.from.first_name);
+  if (messageId) {
+    db.addIdAndName(ticket.ticketId, messageId, ctx.message.from.first_name);
+  }
 
   // Send confirmation message if enabled
   if (!config.autoreply_confirmation) return;
@@ -172,12 +140,12 @@ async function fileHandler(type: string, bot: Addon, ctx: Context) {
     }`;
   if (session.admin && userInfo === undefined) {
     const nameMatch = replyText.match(
-      new RegExp(`${config.language.from} (.*) ${config.language.language}`)
+      new RegExp(`${escapeRegex(config.language.from)} (.*) ${escapeRegex(config.language.language)}`)
     );
     if (!nameMatch) return;
     confirmationMessage = `${config.language.file_sent} ${nameMatch[1]}`;
   }
-  middleware.sendMessage(ctx.chat.id, ticket.messenger, confirmationMessage);
+  sendMessage(ctx.chat.id, ticket.messenger, confirmationMessage);
 };
 
 /**
@@ -205,7 +173,7 @@ async function forwardFile(ctx: Context) {
       return forwardHandler(ctx);
     } else if (cache.ticketSent[cache.userId] === cache.config.spam_cant_msg) {
       cache.ticketSent[cache.userId]++;
-      middleware.sendMessage(ctx.chat.id, ticket.messenger, cache.config.language.blockedSpam, {});
+      sendMessage(ctx.chat.id, ticket.messenger, cache.config.language.blockedSpam, {});
     }
   }
 };

--- a/src/files.ts
+++ b/src/files.ts
@@ -3,6 +3,7 @@ import cache from './cache';
 import { buildInlineKeyboard, reply, sendMessage } from './middleware';
 import { Addon, Context, ModeData } from './interfaces';
 import { ISupportee } from './db';
+import * as log from 'fancy-log'
 
 const escapeRegex = (str: string): string => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
@@ -12,7 +13,7 @@ const escapeRegex = (str: string): string => str.replace(/[.*+?^${}()|[\]\\]/g, 
  * @param ctx - The current bot context.
  * @returns The reply markup object.
  */
-const replyMarkup = (ctx: Context): object => {
+const replyMarkup = (ctx: Context): { html: string; inline_keyboard: Array<Array<{ text: string; url?: string; callback_data?: string }>> } => {
   const { config } = cache;
   const { language, direct_reply } = config;
   const { from, message, session } = ctx;
@@ -45,15 +46,18 @@ const replyMarkup = (ctx: Context): object => {
 async function fileHandler(type: string, bot: Addon, ctx: Context) {
   const { message, session } = ctx;
   const { config } = cache;
-  let userid: string | null;
+  let userid: string | null = null;
   let replyText = '';
 
   // If replying to a message and if the session is admin, extract ticket info
   if (message && message.reply_to_message?.text && session.admin) {
     replyText = message.reply_to_message.text || message.reply_to_message.caption;
     if (!replyText) return;
-    userid = await (await db.getTicketByInternalId(message.external_reply.message_id)).userid;
-    if (!userid) return;
+    const externalReplyId = message.external_reply?.message_id ?? null;
+    if (externalReplyId) {
+      const ticket = await db.getTicketByInternalId(externalReplyId);
+      userid = ticket?.userid ?? null;
+    }
   }
   if (!userid) {
     userid = message.from.id;
@@ -63,7 +67,7 @@ async function fileHandler(type: string, bot: Addon, ctx: Context) {
   let receiverId: string | number = config.staffchat_id;
   let isPrivate = false;
 
-  const ticket = await db.getTicketByUserId(userid, session.groupCategory);
+  const ticket = await db.getTicketByUserId(userid.toString(), session.groupCategory);
   if (!ticket) {
     if (session.admin && userInfo === undefined) {
       reply(ctx, config.language.ticketClosedError);
@@ -73,7 +77,7 @@ async function fileHandler(type: string, bot: Addon, ctx: Context) {
     return;
   }
 
-  let captionText = `${config.language.ticket} #T${ticket.id
+  let captionText = `${config.language.ticket} #T${(ticket.ticketId ?? ticket.id ?? 0)
     .toString()
     .padStart(6, '0')} ${userInfo}\n${message.caption || ''}`;
   if (session.admin && userInfo === undefined) {
@@ -85,7 +89,8 @@ async function fileHandler(type: string, bot: Addon, ctx: Context) {
     isPrivate = true;
   }
 
-  const fileId = (await ctx.getFile()).file_id;
+  const fileResult = await ctx.getFile();
+  const fileId = (fileResult as { file_id: string }).file_id;
   const commonOptions = {
     caption: captionText,
     reply_markup: isPrivate ? replyMarkup(ctx) : {},
@@ -103,28 +108,28 @@ async function fileHandler(type: string, bot: Addon, ctx: Context) {
     case 'document':
       messageId = (await bot.sendDocument(receiverId, fileId, commonOptions)) as string | null;
       if (shouldForwardToGroup) {
-        bot.sendDocument(session.group, fileId, {
+        Promise.resolve(bot.sendDocument(session.group, fileId, {
           caption: captionText,
-          reply_markup: buildInlineKeyboard(ctx.from.id, message.from.first_name, session.groupCategory, ticket.id),
-        });
+          reply_markup: buildInlineKeyboard(ctx.from.id, message.from.first_name, session.groupCategory, (ticket.ticketId ?? ticket.id ?? 0) as number),
+        })).catch(log.error);
       }
       break;
     case 'photo':
       messageId = (await bot.sendPhoto(receiverId, fileId, commonOptions)) as string | null;
       if (shouldForwardToGroup) {
-        bot.sendPhoto(session.group, fileId, {
+        Promise.resolve(bot.sendPhoto(session.group, fileId, {
           caption: captionText,
-          reply_markup: buildInlineKeyboard(ctx.from.id, message.from.first_name, session.groupCategory, ticket.id),
-        });
+          reply_markup: buildInlineKeyboard(ctx.from.id, message.from.first_name, session.groupCategory, (ticket.ticketId ?? ticket.id ?? 0) as number),
+        })).catch(log.error);
       }
       break;
     case 'video':
       messageId = (await bot.sendVideo(receiverId, fileId, commonOptions)) as string | null;
       if (shouldForwardToGroup) {
-        bot.sendVideo(session.group, fileId, {
+        Promise.resolve(bot.sendVideo(session.group, fileId, {
           caption: captionText,
-          reply_markup: buildInlineKeyboard(ctx.from.id, message.from.first_name, session.groupCategory, ticket.id),
-        });
+          reply_markup: buildInlineKeyboard(ctx.from.id, message.from.first_name, session.groupCategory, (ticket.ticketId ?? ticket.id ?? 0) as number),
+        })).catch(log.error);
       }
       break;
   }
@@ -135,7 +140,7 @@ async function fileHandler(type: string, bot: Addon, ctx: Context) {
   // Send confirmation message if enabled
   if (!config.autoreply_confirmation) return;
   let confirmationMessage = `${config.language.confirmationMessage}${config.show_user_ticket
-    ? config.language.yourTicketId + ' #T' + ticket.id.toString().padStart(6, '0')
+    ? config.language.yourTicketId + ' #T' + (ticket.ticketId ?? ticket.id ?? 0).toString().padStart(6, '0')
     : ''
     }`;
   if (session.admin && userInfo === undefined) {
@@ -145,7 +150,7 @@ async function fileHandler(type: string, bot: Addon, ctx: Context) {
     if (!nameMatch) return;
     confirmationMessage = `${config.language.file_sent} ${nameMatch[1]}`;
   }
-  sendMessage(ctx.chat.id, ticket.messenger, confirmationMessage);
+  sendMessage(ctx.chat.id, ticket.messenger, confirmationMessage).catch(log.error);
 };
 
 /**
@@ -154,26 +159,27 @@ async function fileHandler(type: string, bot: Addon, ctx: Context) {
  * @param ctx - The bot context.
  * @param callback - Callback function receiving user information.
  */
-async function forwardFile(ctx: Context) {
-  const ticket = await db.getTicketByUserId(ctx.message.from.id, ctx.session.groupCategory);
+async function forwardFile(ctx: Context): Promise<string | undefined> {
+  const ticket = await db.getTicketByUserId(ctx.message.from.id.toString(), ctx.session.groupCategory);
   let ok = false;
   if (!ticket || !ticket.status || ticket.status === 'closed') {
-    db.add(ctx.message.from.id, 'open', null, ctx.messenger);
+    await db.add(ctx.message.from.id.toString(), 'open', null, ctx.messenger);
     ok = true;
   }
   if (ok || (ticket && ticket.status !== 'banned')) {
-    if (cache.ticketSent[cache.userId] === undefined) {
+    const sentCount = cache.ticketSent[cache.userId];
+    if (sentCount === undefined) {
       setTimeout(() => {
-        cache.ticketSent[cache.userId] = undefined;
+        delete cache.ticketSent[cache.userId];
       }, cache.config.spam_time);
       cache.ticketSent[cache.userId] = 0;
       return forwardHandler(ctx);
-    } else if (cache.ticketSent[cache.userId] < cache.config.spam_cant_msg) {
-      cache.ticketSent[cache.userId]++;
+    } else if (sentCount < cache.config.spam_cant_msg) {
+      cache.ticketSent[cache.userId] = sentCount + 1;
       return forwardHandler(ctx);
-    } else if (cache.ticketSent[cache.userId] === cache.config.spam_cant_msg) {
-      cache.ticketSent[cache.userId]++;
-      sendMessage(ctx.chat.id, ticket.messenger, cache.config.language.blockedSpam, {});
+    } else if (sentCount === cache.config.spam_cant_msg) {
+      cache.ticketSent[cache.userId] = sentCount + 1;
+      sendMessage(ctx.chat.id, ticket?.messenger ?? 'telegram', cache.config.language.blockedSpam, {}).catch(log.error);
     }
   }
 };
@@ -184,7 +190,7 @@ async function forwardFile(ctx: Context) {
  * @param ctx - The bot context.
  * @param callback - Callback function receiving user info (or undefined).
  */
-function forwardHandler(ctx: Context) {
+function forwardHandler(ctx: Context): string | undefined {
   if (ctx.chat.type === 'private') {
     cache.userId = ctx.message.from.id;
     const userInfo = `${cache.config.language.from} ${ctx.message.from.first_name} ${cache.config.language.language}: ${ctx.message.from.language_code}\n\n`;

--- a/src/files.ts
+++ b/src/files.ts
@@ -3,7 +3,7 @@ import cache from './cache';
 import { buildInlineKeyboard, reply, sendMessage } from './middleware';
 import { Addon, Context, ModeData } from './interfaces';
 import { ISupportee } from './db';
-import * as log from 'fancy-log'
+import * as log from './logger'
 
 const escapeRegex = (str: string): string => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -7,7 +7,7 @@ import cache from './cache';
 import { Addon, Context } from './interfaces';
 import * as analytics from './analytics';
 import * as workflows from './workflows';
-import * as log from 'fancy-log'
+import * as log from './logger'
 
 export function registerCommonHandlers(addon: Addon, keys?: string[][]) {
   // Register commands common to both platforms.

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -4,33 +4,54 @@ import * as inline from './inline';
 import * as files from './files';
 import * as text from './text';
 import cache from './cache';
+import { Addon, Context } from './interfaces';
+import * as analytics from './analytics';
+import * as workflows from './workflows';
 import * as log from 'fancy-log'
 
-export function registerCommonHandlers(addon: any, keys?: any) {
+export function registerCommonHandlers(addon: Addon, keys?: string[][]) {
   // Register commands common to both platforms.
-  addon.command('open', (ctx: any) => commands.openCommand(ctx));
-  addon.command('close', (ctx: any) => commands.closeCommand(ctx));
-  addon.command('ban', (ctx: any) => commands.banCommand(ctx));
-  addon.command('reopen', (ctx: any) => commands.reopenCommand(ctx));
-  addon.command('unban', (ctx: any) => commands.unbanCommand(ctx));
-  addon.command('clear', (ctx: any) => commands.clearCommand(ctx));
+  addon.command('open', (ctx: Context) => commands.openCommand(ctx));
+  addon.command('close', (ctx: Context) => commands.closeCommand(ctx));
+  addon.command('ban', (ctx: Context) => commands.banCommand(ctx));
+  addon.command('reopen', (ctx: Context) => commands.reopenCommand(ctx));
+  addon.command('unban', (ctx: Context) => commands.unbanCommand(ctx));
+  addon.command('clear', (ctx: Context) => commands.clearCommand(ctx));
 
-  addon.command('id', (ctx: any) =>
+  // Team collaboration commands
+  addon.command('assign', (ctx: Context) => commands.assignCommand(ctx));
+  addon.command('unassign', (ctx: Context) => commands.unassignCommand(ctx));
+  addon.command('tag', (ctx: Context) => commands.tagCommand(ctx));
+  addon.command('untag', (ctx: Context) => commands.untagCommand(ctx));
+  addon.command('priority', (ctx: Context) => commands.priorityCommand(ctx));
+  addon.command('mute', (ctx: Context) => commands.muteCommand(ctx));
+  addon.command('unmute', (ctx: Context) => commands.unmuteCommand(ctx));
+  addon.command('note', (ctx: Context) => commands.noteCommand(ctx));
+  addon.command('notes', (ctx: Context) => commands.notesCommand(ctx));
+  addon.command('staff', (ctx: Context) => commands.listStaffCommand(ctx));
+
+  // Analytics commands
+  addon.command('stats', (ctx: Context) => commands.statsCommand(ctx));
+
+  // Workflow commands
+  addon.command('templates', (ctx: Context) => commands.templatesCommand(ctx));
+
+  addon.command('id', (ctx: Context) =>
     middleware.reply(ctx, `User ID: ${ctx.from.id}\nGroup ID: ${ctx.chat.id}`, {
       parse_mode: cache.config.parse_mode,
     })
   );
 
-  addon.command('faq', (ctx: any) =>
+  addon.command('faq', (ctx: Context) =>
     middleware.reply(ctx, cache.config.language.faqCommandText, {
       parse_mode: cache.config.parse_mode,
     })
   );
 
-  addon.command('help', (ctx: any) => commands.helpCommand(ctx));
+  addon.command('help', (ctx: Context) => commands.helpCommand(ctx));
 
   // Common "links" command with platform-specific URL handling.
-  addon.command('links', (ctx: any) => {
+  addon.command('links', (ctx: Context) => {
     let links = '';
     const subcategories: string[] = [];
     for (const cat of cache.config.categories) {
@@ -45,7 +66,10 @@ export function registerCommonHandlers(addon: any, keys?: any) {
               subcategories.push(id);
               let url = '';
               if (addon.platform === 'telegram' && addon.botInfo) {
-                  url = `https://t.me/${addon.botInfo.username}?start=${id}`;
+                  const botUsername = addon.botInfo.username as string | undefined;
+                  if (botUsername) {
+                    url = `https://t.me/${botUsername}?start=${id}`;
+                  }
               }
               links += `${catName} - ${url}\n`;
             }
@@ -59,7 +83,7 @@ export function registerCommonHandlers(addon: any, keys?: any) {
   });
 
   if (cache.config.pass_start === false) {
-    addon.command('start', (ctx: any) => {
+    addon.command('start', (ctx: Context) => {
       if (ctx.chat.type === 'private') {
         middleware.reply(ctx, cache.config.language.startCommandText);
         if (cache.config.categories && cache.config.categories.length > 0) {
@@ -81,27 +105,63 @@ export function registerCommonHandlers(addon: any, keys?: any) {
   }
 
   // Register event handlers for callback queries and file types.
-  addon.on('callback_query', (ctx: any) => inline.callbackQuery(ctx));
-  addon.on([':photo'], (ctx: any) => files.fileHandler('photo', addon, ctx));
-  addon.on([':video'], (ctx: any) => files.fileHandler('video', addon, ctx));
-  addon.on([':document'], (ctx: any) => files.fileHandler('document', addon, ctx));
+  addon.on('callback_query', async (ctx: Context) => {
+    // Handle CSAT rating callbacks
+    if (ctx.callbackQuery.data && ctx.callbackQuery.data.startsWith('csat:')) {
+      const parts = ctx.callbackQuery.data.split(':');
+      const ticketId = parseInt(parts[1], 10);
+      const rating = parseInt(parts[2], 10);
+      await analytics.handleCSATCallback(ticketId, rating);
+      await ctx.answerCbQuery(cache.config.language.csatThankYou || 'Thank you!');
+      return;
+    }
+    inline.callbackQuery(ctx);
+  });
+  addon.on([':photo'], (ctx: Context) => files.fileHandler('photo', addon, ctx));
+  addon.on([':video'], (ctx: Context) => files.fileHandler('video', addon, ctx));
+  addon.on([':document'], (ctx: Context) => files.fileHandler('document', addon, ctx));
 
   // Register generic text handlers.
-  addon.hears(cache.config.language.back, (ctx: any) => {
+  addon.hears(cache.config.language.back, (ctx: Context) => {
     if (addon.platform === 'telegram' && keys) {
       middleware.reply(ctx, cache.config.language.services, inline.replyKeyboard(keys));
     } else {
       middleware.reply(ctx, cache.config.language.services, []);
     }
   });
-  addon.hears('testing', (ctx: any) => text.handleText(addon, ctx, keys || []));
-  addon.hears(/(.+)/, (ctx: any) => text.handleText(addon, ctx, keys || []));
+
+  // Handle canned response commands (/key pattern)
+  addon.hears(/^(\/\w+)$/, async (ctx: Context) => {
+    const cmd = ctx.match?.substring(1);
+    if (!cmd || !ctx.session.admin) return;
+
+    // Check if this is a canned response key
+    const cannedText = workflows.getCannedResponse(cmd);
+    if (cannedText) {
+      // If replying to a ticket, send the canned response as reply
+      const replyMsg = ctx.message?.reply_to_message;
+      if (replyMsg && replyMsg.text) {
+        const replyText = replyMsg.text || replyMsg.caption;
+        const match = replyText.match(/#T(.*)/);
+        if (match) {
+          // Store canned text on context for staff handler to pick up
+          ctx.message.text = cannedText;
+          return; // Let the regular chat handler process it
+        }
+      }
+      middleware.reply(ctx, `Template "${cmd}":\n\n${cannedText}`, { parse_mode: cache.config.parse_mode });
+    }
+  });
+
+  addon.hears('testing', (ctx: Context) => text.handleText(addon, ctx, keys || []));
+  addon.hears(/(.+)/, (ctx: Context) => text.handleText(addon, ctx, keys || []));
 
   // Global error handling.
-  addon.catch((err: any, ctx: any) => {
+  addon.catch(async (err: Error, ctx?: Context): Promise<void> => {
     log.error('Error: ', err);
+    if (!ctx || !ctx.message) return;
     try {
-      middleware.reply(ctx, 'Message is not sent due to an error.');
+      await middleware.reply(ctx, 'Message is not sent due to an error.');
     } catch (e) {
       log.error('Could not send error msg to chat: ', e);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import * as team from './team';
 import * as analytics from './analytics';
 import * as workflows from './workflows';
 import * as recovery from './recovery';
-import * as log from 'fancy-log'
+import * as log from './logger'
 
 /**
  * Check and migrate SQLite database to MongoDB.

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,12 @@ import * as db from './db';
 import * as error from './error';
 import TelegramAddon from './addons/telegram';
 import SignalAddon from './addons/signal';
+import SlackAddon from './addons/slack';
+import DiscordAddon from './addons/discord';
+import * as team from './team';
+import * as analytics from './analytics';
+import * as workflows from './workflows';
+import * as recovery from './recovery';
 import * as log from 'fancy-log'
 
 /**
@@ -55,6 +61,20 @@ function createAddons(): Addon[] {
     addons.push(signalAddon);
   }
 
+  // Create Slack addon if enabled.
+  if (cache.config && cache.config.slack_enabled) {
+    const slackAddon = SlackAddon.getInstance();
+    (slackAddon as any).platform = 'slack';
+    addons.push(slackAddon);
+  }
+
+  // Create Discord addon if enabled.
+  if (cache.config && cache.config.discord_enabled) {
+    const discordAddon = DiscordAddon.getInstance();
+    (discordAddon as any).platform = 'discord';
+    addons.push(discordAddon);
+  }
+
   return addons;
 }
 
@@ -64,6 +84,16 @@ function createAddons(): Addon[] {
 async function main(logs = true) {
   await db.connect();
   await checkAndMigrateDatabase();
+
+  // Run startup recovery: scan chat history to discover highest ticket ID
+  try {
+    await recovery.runRecovery();
+  } catch (err) {
+    log.error('Startup recovery failed — bot will continue with DB-only fallback:', err);
+  }
+
+  // Initialize staff member cache from config
+  team.initStaffCache();
 
   // Create and store all enabled addons.
   const addons = createAddons();
@@ -78,6 +108,39 @@ async function main(logs = true) {
   addons.forEach((addon) => {
     addon.start();
   });
+
+  // Set up daily summary cron job
+  const summaryTime = cache.config.daily_summary_time || '09:00';
+  if (summaryTime) {
+    const [hours, minutes] = summaryTime.split(':').map(Number);
+    const runDailySummary = () => {
+      analytics.sendDailySummary().then(() => {
+        // Schedule for next day at the same time
+        const now = new Date();
+        const target = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1, hours, minutes);
+        const delay = target.getTime() - now.getTime();
+        setTimeout(runDailySummary, delay);
+      });
+    };
+
+    // Calculate initial delay to first run time
+    const now = new Date();
+    const targetToday = new Date(now.getFullYear(), now.getMonth(), now.getDate(), hours, minutes);
+    let delay = targetToday.getTime() - now.getTime();
+    if (delay < 0) {
+      // If the time has already passed today, schedule for tomorrow
+      delay += 86400000;
+    }
+    setTimeout(runDailySummary, Math.max(delay, 0));
+    log.info(`Daily summary scheduled at ${summaryTime} UTC (first run in ${Math.round(delay / 60000)} min)`);
+  }
+
+  // Set up periodic workflow checks (every 30 minutes)
+  const workflowInterval = setInterval(() => {
+    workflows.runWorkflowChecks();
+  }, 30 * 60 * 1000);
+  workflowInterval.unref(); // Don't keep process alive
+  log.info('Workflow periodic checks started (every 30 min)');
 }
 
 main();

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,13 +67,9 @@ async function main(logs = true) {
 
   // Create and store all enabled addons.
   const addons = createAddons();
-  // cache.addons = addons;
 
   // Initialize the webserver if enabled and if there's a Telegram addon.
   const telegramAddon = addons.find((addon) => (addon as any).platform === 'telegram');
-  if (cache.config.web_server && telegramAddon) {
-    // webserver.init(telegramAddon);
-  }
 
   // Initialize global error handling.
   error.init(logs);

--- a/src/inline.ts
+++ b/src/inline.ts
@@ -3,7 +3,7 @@ import TelegramAddon from './addons/telegram';
 import cache from './cache';
 import * as middleware from './middleware';
 import * as team from './team';
-import * as log from 'fancy-log'
+import * as log from './logger'
 
 /**
  * Helper function for reply keyboard.

--- a/src/inline.ts
+++ b/src/inline.ts
@@ -2,12 +2,11 @@ import { Context, Messenger, ModeData } from './interfaces';
 import TelegramAddon from './addons/telegram';
 import cache from './cache';
 import * as middleware from './middleware';
+import * as team from './team';
+import * as log from 'fancy-log'
 
 /**
  * Helper function for reply keyboard.
- *
- * @param keys - Keyboard keys.
- * @returns An object containing reply_markup.
  */
 const replyKeyboard = (keys: any[]) => ({
   parse_mode: cache.config.parse_mode,
@@ -16,8 +15,6 @@ const replyKeyboard = (keys: any[]) => ({
 
 /**
  * Helper function to remove keyboard.
- *
- * @returns An object with remove_keyboard option.
  */
 const removeKeyboard = () => ({
   parse_mode: cache.config.parse_mode,
@@ -126,20 +123,47 @@ function initInline(bot: TelegramAddon) {
 }
 
 /**
- * Handles callback queries.
- *
- * @param ctx - The context of the callback.
+ * Handles callback queries (assignment, private chat, CSAT).
  */
-function callbackQuery(ctx: Context) {
+async function callbackQuery(ctx: Context) {
+  const data = ctx.callbackQuery.data;
+
+  // Handle assignment callbacks: assign:<staff_id>:<ticketId>
+  if (data && data.startsWith('assign:')) {
+    const parts = data.split(':');
+    const staffId = parts[1];
+    const ticketId = parseInt(parts[2]);
+
+    if (!team.canPerformAction(ctx.callbackQuery.from.id.toString(), 'assign')) {
+      await ctx.answerCbQuery('You cannot assign tickets.', true);
+      return;
+    }
+
+    await team.assignTicketCommand(ctx, staffId, ticketId);
+    await ctx.answerCbQuery('Ticket assigned!', true);
+    return;
+  }
+
+  // Handle unassign callback: unassign:<ticketId>
+  if (data && data.startsWith('unassign:')) {
+    const parts = data.split(':');
+    const ticketId = parseInt(parts[1]);
+
+    await team.unassignTicketCommand(ctx, ticketId);
+    await ctx.answerCbQuery('Ticket unassigned.', true);
+    return;
+  }
+
   // End callback session if data equals 'R'
-  if (ctx.callbackQuery.data === 'R') {
+  if (data === 'R') {
     ctx.session.mode = '';
     ctx.session.modeData = {} as ModeData;
     middleware.reply(ctx, cache.config.language.prvChatEnded);
     return;
   }
+
   // Extract parts from callback data.
-  const [id, name, category, ticketid] = ctx.callbackQuery.data.split('---');
+  const [id, name, category, ticketid] = data.split('---');
 
   ctx.session.mode = 'private_reply';
   ctx.session.modeData = {
@@ -167,7 +191,7 @@ function callbackQuery(ctx: Context) {
         ],
       ],
     },
-  });
+  }).catch(log.error);
 
   ctx.answerCbQuery(cache.config.language.instructionsSent, true);
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -3,7 +3,7 @@ import TelegramAddon from './addons/telegram';
 export interface ModeData {
   ticketid: string;
   userid: string | number;
-  name: any;
+  name: string | null;
   category: string;
 }
 
@@ -15,7 +15,7 @@ export interface SessionData {
   groupCategory: string | null;
   groupTag: string;
   group: string;
-  groupAdmin: any;
+  groupAdmin: boolean | null;
   getSessionKey: Function;
 }
 
@@ -129,9 +129,9 @@ export class Config {
 
 export interface Cache {
   userId: string;
-  ticketIDs: any;
-  ticketStatus: any;
-  ticketSent: any;
+  ticketIDs: (string | number)[];
+  ticketStatus: Record<string, boolean>;
+  ticketSent: Record<string, number>;
   html: string;
   noSound: string;
   markdown: string;
@@ -181,11 +181,11 @@ export class Context {
     type: string;
   };
   session: SessionData;
-  callbackQuery: { data: string; from: { id: any }; id: any };
-  from: { username: any; id: string };
-  inlineQuery: any;
+  callbackQuery: { data: string; from: { id: string | number }; id: string };
+  from: { username: string; id: string | number };
+  inlineQuery: unknown;
   reply: Function;
-  answerCbQuery: (arg0: any, arg1: boolean) => void;
+  answerCbQuery: (arg0?: unknown, arg1?: boolean) => void;
   getChat: Function;
   getFile: Function;
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -230,6 +230,7 @@ export class Config {
   web_server_ssl_cert: string = '';
   web_server_ssl_key: string = '';
   dev_mode: boolean = false;
+  log_level: 'NONE' | 'ERROR' | 'INFO' = 'NONE';
   show_user_ticket: boolean = false;
   language: Language = {} as Language;
   autoreply_confirmation: boolean = true;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -15,13 +15,113 @@ export interface SessionData {
   groupCategory: string | null;
   groupTag: string;
   group: string;
-  groupAdmin: boolean | null;
-  getSessionKey: Function;
+  groupAdmin: string | boolean | null | undefined;
+  staffRole?: 'admin' | 'supervisor' | 'agent';
+  getSessionKey: (ctx: Context) => string | null;
 }
 
 export interface Autoreply {
   question: string;
   answer: string;
+}
+
+export enum StaffRole {
+  AGENT = 'agent',
+  SUPERVISOR = 'supervisor',
+  ADMIN = 'admin',
+}
+
+export enum TicketPriority {
+  LOW = 'low',
+  NORMAL = 'normal',
+  HIGH = 'high',
+  URGENT = 'urgent',
+}
+
+export interface StaffMemberConfig {
+  telegram_id: string;
+  role: StaffRole;
+  name: string;
+}
+
+export interface WebhookConfig {
+  url: string;
+  events: WebhookEvent[];
+  secret?: string;
+}
+
+export type WebhookEvent =
+  | 'ticket.created'
+  | 'ticket.replied'
+  | 'ticket.closed'
+  | 'ticket.banned'
+  | 'csat.rated'
+  | 'ticket.escalated';
+
+export interface CannedResponse {
+  key: string;
+  text: string;
+}
+
+export interface EscalationRule {
+  after_hours: number;
+  action: 'notify_supervisor' | 'tag_urgent';
+}
+
+export interface BusinessHoursConfig {
+  enabled: boolean;
+  start: string;
+  end: string;
+  timezone: string;
+  offline_message?: string;
+}
+
+export interface WebChatConfig {
+  enabled: boolean;
+  greeting: string;
+  primary_color: string;
+  logo_url: string;
+  position: 'left' | 'right';
+  pre_chat_form: {
+    name: boolean;
+    email: boolean;
+    subject: boolean;
+    order_number: boolean;
+  };
+  business_hours?: BusinessHoursConfig;
+}
+
+export interface SlackConfig {
+  enabled: boolean;
+  bot_token: string;
+  channel_id: string;
+}
+
+export interface DiscordConfig {
+  enabled: boolean;
+  bot_token: string;
+  channel_id: string;
+}
+
+export interface LLMConfig {
+  use_llm: boolean;
+  llm_api_key: string;
+  llm_base_url: string;
+  llm_model: string;
+  llm_knowledge: string;
+  llm_memory_depth: number;
+  auto_triage: boolean;
+  sentiment_alert_threshold: number;
+  staff_assist: boolean;
+  translate_enabled: boolean;
+  translate_target_language: string;
+}
+
+export interface WorkflowConfig {
+  canned_responses: CannedResponse[];
+  escalation_rules: EscalationRule[];
+  auto_close_after_days: number;
+  business_hours?: BusinessHoursConfig;
 }
 
 export interface Language {
@@ -69,6 +169,24 @@ export interface Language {
   helpCommandStaffText: string;
   regardsGroup: string;
   autoreply: Autoreply[];
+  // CSAT survey strings
+  csatRatingRequest: string;
+  csatThankYou: string;
+  // Triage / priority strings
+  triagePriority: string;
+  triageSummary: string;
+  sentimentAlert: string;
+  // Assignment strings
+  ticketAssignedTo: string;
+  ticketUnassigned: string;
+  assignedBy: string;
+  // Internal note strings
+  internalNote: string;
+  noteAddedBy: string;
+  // Workflow strings
+  offlineMessage: string;
+  businessHoursClosed: string;
+  escalationNotify: string;
 }
 
 export interface Category {
@@ -90,12 +208,12 @@ export enum ParseMode {
 }
 
 export class Config {
-  bot_token: string;
-  spam_cant_msg: number;
-  staffchat_id: string | number;
+  bot_token: string = '';
+  spam_cant_msg: number = 0;
+  staffchat_id: string | number = '';
   staffchat_type: Messenger = Messenger.TELEGRAM;
   staffchat_parse_mode: ParseMode = ParseMode.MarkdownV2;
-  owner_id: string;
+  owner_id: string = '';
   spam_time: number = 5;
   parse_mode: string = ParseMode.MarkdownV2;
   allow_private: boolean = false;
@@ -113,38 +231,88 @@ export class Config {
   web_server_ssl_key: string = '';
   dev_mode: boolean = false;
   show_user_ticket: boolean = false;
-  language: Language;
+  language: Language = {} as Language;
   autoreply_confirmation: boolean = true;
-  autoreply: Autoreply[];
+  autoreply: Autoreply[] = [];
   clean_replies: boolean = false;
   pass_start: boolean = false;
   categories: Category[] = [];
   mongodb_uri: string = 'mongodb://mongodb:27017/support';
+  // LLM settings (legacy flat fields for backward compat)
   use_llm: boolean = false;
-  llm_api_key: string;
-  llm_base_url: string;
-  llm_model: string;
-  llm_knowledge: string;
+  llm_api_key: string = '';
+  llm_base_url: string = '';
+  llm_model: string = '';
+  llm_knowledge: string = '';
+  // New AI features
+  llm_memory_depth: number = 10;
+  auto_triage: boolean = false;
+  sentiment_alert_threshold: number = 2;
+  staff_assist: boolean = false;
+  translate_enabled: boolean = false;
+  translate_target_language: string = 'en';
+  // Team collaboration
+  staff_roles: StaffMemberConfig[] = [];
+  enable_csat: boolean = false;
+  daily_summary_time: string = '09:00';
+  // Webhooks
+  webhooks: WebhookConfig[] = [];
+  // Integrations
+  slack_enabled: boolean = false;
+  slack_bot_token: string = '';
+  slack_channel_id: string = '';
+  discord_enabled: boolean = false;
+  discord_bot_token: string = '';
+  discord_channel_id: string = '';
+  api_enabled: boolean = false;
+  api_token: string = '';
+  // Web chat widget
+  web_chat: WebChatConfig = {
+    enabled: false,
+    greeting: 'Hi! How can we help you?',
+    primary_color: '#6366f1',
+    logo_url: '',
+    position: 'right',
+    pre_chat_form: { name: true, email: true, subject: false, order_number: false },
+  };
+  // Workflows & automation
+  canned_responses: CannedResponse[] = [];
+  escalation_rules: EscalationRule[] = [];
+  auto_close_after_days: number = 0;
+}
+
+export interface SocketEmit {
+  emit(event: string, data: unknown): void;
+}
+
+export interface SocketTo {
+  to(roomId: string): SocketEmit;
 }
 
 export interface Cache {
   userId: string;
-  ticketIDs: (string | number)[];
+  ticketIDs: Record<string, string | number>;
   ticketStatus: Record<string, boolean>;
-  ticketSent: Record<string, number>;
+  ticketSent: Record<string, number | undefined>;
   html: string;
   noSound: string;
   markdown: string;
-  io: any;
+  io: SocketTo;
   config: Config;
+  // Team collaboration cache
+  staffMembers: Map<string, StaffMemberConfig>;
+  mutedTickets: Set<string>;
+  // Recovery baseline — highest ticket ID discovered from chat history on startup
+  recoveryBaseline: number;
 }
 
 /**
  * Context
  */
 export class Context {
-  messenger: Messenger = null;
-  update_id: number;
+  messenger: Messenger = 'telegram' as Messenger;
+  update_id: number = 0;
+  match?: string;
   message: {
     web_msg: boolean;
     message_id: number;
@@ -168,36 +336,39 @@ export class Context {
       text: string;
       caption: string;
     };
-    external_reply: {
+    external_reply?: {
       message_id: number,
     },
     getFile?: any;
     caption: string;
-  };
+  } = {} as Context['message'];
   chat: {
     id: string;
     first_name: string;
     username: string;
     type: string;
-  };
-  session: SessionData;
-  callbackQuery: { data: string; from: { id: string | number }; id: string };
-  from: { username: string; id: string | number };
-  inlineQuery: unknown;
-  reply: Function;
-  answerCbQuery: (arg0?: unknown, arg1?: boolean) => void;
-  getChat: Function;
-  getFile: Function;
+  } = {} as Context['chat'];
+  session: SessionData = {} as SessionData;
+  callbackQuery: { data: string; from: { id: string | number }; id: string } = { data: '', from: { id: '' }, id: '' };
+  from: { username: string; id: string | number } = { username: '', id: '' };
+  inlineQuery: unknown = null;
+  reply: (text: string, options?: Record<string, unknown>) => Promise<void> = async () => {};
+  answerCbQuery: (text?: string, showAlert?: boolean) => Promise<void> = async () => {};
+  getChat: () => Promise<{ id: string; first_name: string; username: string; type: string }> = async () => ({ id: '', first_name: '', username: '', type: 'private' });
+  getFile: () => Promise<unknown> = async () => {};
 }
 
 export interface Addon {
+  platform?: string;
+  botInfo?: Record<string, unknown>;
+
   /**
    * Sends a text message.
    * @param chatId The target chat identifier.
    * @param text The text message to send.
    * @param options Optional parameters.
    */
-  sendMessage(chatId: string | number, text: string, options?: any): void | Promise<void> | Promise<string | null>;
+  sendMessage(chatId: string | number, text: string, options?: Record<string, unknown>): void | Promise<void> | Promise<string | null>;
 
   /**
    * Sends a photo.
@@ -205,7 +376,7 @@ export interface Addon {
    * @param photo The photo content to send.
    * @param options Optional parameters (e.g. caption, recipients).
    */
-  sendPhoto(chatId: string | number, photo: any, options?: any): void | Promise<void> | Promise<string | null>;
+  sendPhoto(chatId: string | number, photo: unknown, options?: Record<string, unknown>): Promise<void> | Promise<string | null>;
 
   /**
    * Sends a document.
@@ -213,7 +384,7 @@ export interface Addon {
    * @param document The document content to send.
    * @param options Optional parameters (e.g. caption, recipients).
    */
-  sendDocument(chatId: string | number, document: any, options?: any): void | Promise<void> | Promise<string | null>;
+  sendDocument(chatId: string | number, document: unknown, options?: Record<string, unknown>): Promise<void> | Promise<string | null>;
 
   /**
    * Sends a video.
@@ -221,21 +392,21 @@ export interface Addon {
    * @param video The video content to send.
    * @param options Optional parameters (e.g. caption, recipients).
    */
-  sendVideo(chatId: string | number, video: any, options?: any): void | Promise<void> | Promise<string | null>;
+  sendVideo(chatId: string | number, video: unknown, options?: Record<string, unknown>): Promise<void> | Promise<string | null>;
 
   /**
    * Registers a command handler.
    * @param command The command string (e.g. 'start', 'help').
    * @param callback The function to handle the command.
    */
-  command(command: string, callback: (ctx: any) => void): void;
+  command(command: string, callback: (ctx: Context) => void): void;
 
   /**
    * Registers an event handler.
    * @param event The event name or an array of event names.
    * @param callback The function to handle the event.
    */
-  on(event: string | string[], callback: (ctx: any) => void): void;
+  on(event: string | string[], callback: (ctx: Context) => void): void;
 
   /**
    * Starts the addon (e.g. begin processing incoming messages).
@@ -246,7 +417,12 @@ export interface Addon {
    * Sets up an error handler.
    * @param handler The error handler function.
    */
-  catch(handler: (error: any, ctx?: any) => void): void;
+  catch(handler: (error: Error, ctx?: Context) => void): void;
+
+  /**
+   * Registers a text/regex handler.
+   */
+  hears(trigger: string | string[] | RegExp, callback: (ctx: Context) => void): void;
 }
 
 export enum Messenger {

--- a/src/language.ts
+++ b/src/language.ts
@@ -1,0 +1,75 @@
+import { Language } from './interfaces';
+
+// Default language strings — used when config doesn't provide them
+export const defaultLanguage: Partial<Language> = {
+  startCommandText: '/start - Start the bot',
+  faqCommandText: '/faq - Frequently Asked Questions',
+  helpCommandText: '/help - Get help',
+  confirmationMessage: 'Your message has been sent. We will get back to you as soon as possible.',
+  contactMessage: '',
+  blockedSpam: 'You are blocked due to spam.',
+  ticket: 'Ticket',
+  closed: 'Closed',
+  acceptedBy: 'Accepted by',
+  dear: 'Dear',
+  regards: 'Regards',
+  from: 'from',
+  language: 'Language',
+  msg_sent: 'Message sent!',
+  file_sent: 'File sent!',
+  usr_with_ticket: 'User with ticket',
+  banned: 'Banned',
+  replyPrivate: 'Reply in private chat',
+  services: 'Services',
+  customer: 'Customer',
+  msgForwarding: 'Message forwarding',
+  back: 'Back',
+  whatSubCategory: 'What sub-category?',
+  prvChatEnded: 'Private chat ended.',
+  prvChatOpened: 'Private chat opened.',
+  prvChatEnd: 'End private chat',
+  prvChatOpenedCustomer: 'Staff has opened a private chat with you.',
+  instructionsSent: 'Instructions sent!',
+  openTickets: 'Open Tickets',
+  support: 'Support',
+  prvChatOnly: 'Private chat only',
+  ticketClosed: 'Ticket closed',
+  links: 'Links',
+  textFirst: 'Please send a text message first.',
+  ticketClosedError: 'This ticket is closed. Please open a new one.',
+  automatedReply: 'Automated Reply',
+  automatedReplyAuthor: 'Support Team',
+  doesntHelp: "That doesn't help",
+  automatedReplySent: 'An automated reply has been sent.',
+  ticketReopened: 'Ticket reopened!',
+  yourTicketId: 'Your Ticket ID',
+  helpCommandStaffText: '/help - Staff commands reference',
+  regardsGroup: 'Regards, Support Team',
+  csatRatingRequest: 'Please rate your support experience (1-5):',
+  csatThankYou: 'Thank you for your feedback!',
+  triagePriority: 'Priority',
+  triageSummary: 'Triage Summary',
+  sentimentAlert: 'Sentiment Alert',
+  ticketAssignedTo: 'Ticket assigned to',
+  ticketUnassigned: 'Ticket unassigned',
+  assignedBy: 'Assigned by',
+  internalNote: 'Internal Note',
+  noteAddedBy: 'Note added by',
+  offlineMessage: "We're currently offline. We'll get back to you when we're available.",
+  businessHoursClosed: 'Our support hours are from {start} to {end}.',
+  escalationNotify: 'This ticket has been escalated.',
+};
+
+/**
+ * Merges the user's language block over the defaults so every string is defined,
+ * even when the config has no language block at all.
+ * Older configs customised the confirmation text via the legacy contactMessage key.
+ */
+export function mergeLanguage(userLanguage: unknown): Language {
+  const user: Partial<Language> =
+    userLanguage && typeof userLanguage === 'object' ? { ...(userLanguage as Partial<Language>) } : {};
+  if (!user.confirmationMessage && user.contactMessage) {
+    user.confirmationMessage = user.contactMessage;
+  }
+  return { ...defaultLanguage, ...user } as unknown as Language;
+}

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,53 @@
+import * as fs from 'fs';
+import * as fancyLog from 'fancy-log';
+
+const debugFile = './config/debug.log';
+
+/** Lazily reads log_level from config.yaml directly (avoids circular dep via cache). */
+let cachedLogLevel: string | undefined;
+function getLogLevel(): string {
+  if (cachedLogLevel !== undefined) return cachedLogLevel;
+  try {
+    const YAML = require('yaml');
+    const content = fs.readFileSync('./config/config.yaml', 'utf8');
+    const parsed = YAML.parse(content);
+    cachedLogLevel = (parsed.log_level as string) || 'NONE';
+  } catch (_e) {
+    cachedLogLevel = 'NONE';
+  }
+  return cachedLogLevel;
+}
+
+/** Returns a formatted ISO timestamp string. */
+function ts(): string {
+  return new Date().toISOString();
+}
+
+/** Appends a timestamped message to the debug log file if the current level permits it. */
+function appendToFile(msg: string, level: 'info' | 'error'): void {
+  const lvl = getLogLevel();
+  if (lvl === 'NONE') return;
+  if (lvl === 'ERROR' && level === 'info') return;
+
+  try {
+    fs.appendFileSync(debugFile, `[${ts()}] ${msg}\n`, 'utf8');
+  } catch (_e) {
+    // Silently ignore file write errors.
+  }
+}
+
+/** Wraps fancy-log.info: always logs to stdout, writes to debug.log if level allows. */
+function info(...args: unknown[]): void {
+  const msg = args.map((a) => (typeof a === 'string' ? a : JSON.stringify(a))).join(' ');
+  appendToFile(msg, 'info');
+  fancyLog.info.apply(null, args as [any]);
+}
+
+/** Wraps fancy-log.error: always logs to stdout, writes to debug.log if level allows. */
+function error(...args: unknown[]): void {
+  const msg = args.map((a) => (typeof a === 'string' ? a : JSON.stringify(a))).join(' ');
+  appendToFile(msg, 'error');
+  fancyLog.error.apply(null, args as [any]);
+}
+
+export { info, error };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -103,7 +103,9 @@ const reply = async (
   msgText: string,
   extra: any = { parse_mode: cache.config.parse_mode }
 ): Promise<void> => {
-  await sendMessage(ctx.message.chat.id, ctx.messenger, msgText, extra);
+  const chatId = ctx.message?.chat?.id ?? ctx.chat?.id;
+  if (!chatId) return;
+  await sendMessage(chatId, ctx.messenger, msgText, extra);
 };
 
 export { buildInlineKeyboard, strictEscape, sendMessage, reply };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -4,6 +4,32 @@ import { Context, Messenger } from './interfaces';
 import TelegramAddon from './addons/telegram';
 
 /**
+ * Builds an inline keyboard with a "Reply Private" button.
+ *
+ * @param userId - The user's ID.
+ * @param firstName - The user's first name.
+ * @param category - The ticket category.
+ * @param ticketId - The ticket identifier.
+ * @returns The reply markup object.
+ */
+const buildInlineKeyboard = (
+  userId: string | number,
+  firstName: string,
+  category: string | null,
+  ticketId: string | number,
+): object => ({
+  html: '',
+  inline_keyboard: [
+    [
+      {
+        text: cache.config.language.replyPrivate,
+        callback_data: `${userId}---${firstName}---${category}---${ticketId}`,
+      },
+    ],
+  ],
+});
+
+/**
  * Escapes special characters for MarkdownV2, HTML, or Markdown formats.
  *
  * @param str - The string to escape.
@@ -72,12 +98,12 @@ async function sendMessage (
  * @param msgText - The reply text.
  * @param extra - Extra options (default includes the configured parse mode).
  */
-const reply = (
+const reply = async (
   ctx: Context,
   msgText: string,
   extra: any = { parse_mode: cache.config.parse_mode }
-): void => {
-  sendMessage(ctx.message.chat.id, ctx.messenger, msgText, extra);
+): Promise<void> => {
+  await sendMessage(ctx.message.chat.id, ctx.messenger, msgText, extra);
 };
 
-export { strictEscape, sendMessage, reply };
+export { buildInlineKeyboard, strictEscape, sendMessage, reply };

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -2,14 +2,20 @@
 import mongoose, { Model } from 'mongoose';
 import cache from './cache';
 import { ISupportee, SupporteeSchema } from './db';
-import * as log from 'fancy-log'
+import * as log from './logger'
 
-const MONGO_URI = cache.config.mongodb_uri || 'mongodb://localhost:27017/support';
-const collectionName = `bot_${cache.config.owner_id}_${cache.config.bot_token.slice(-5)}`;
+// Lazy config accessors — defer reading cache.config until runtime
+function getMongoUri(): string {
+  return cache.config?.mongodb_uri || 'mongodb://localhost:27017/support';
+}
+
+function getCollectionName(): string {
+  return `bot_${cache.config?.owner_id}_${cache.config?.bot_token?.slice(-5) || ''}`;
+}
 
 const Supportee: Model<ISupportee> = 
-  mongoose.models[collectionName] as Model<ISupportee> ||
-  mongoose.model<ISupportee>(collectionName, SupporteeSchema);
+  mongoose.models[getCollectionName()] as Model<ISupportee> ||
+  mongoose.model<ISupportee>(getCollectionName(), SupporteeSchema);
 
 export const migrateData = async () => {
   let sqliteDb;
@@ -20,7 +26,7 @@ export const migrateData = async () => {
     // better-sqlite3 not available, skip migration
     return;
   }
-  await mongoose.connect(MONGO_URI);
+  await mongoose.connect(getMongoUri());
 
   try {
     // Fetch all records from SQLite

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -1,7 +1,7 @@
 import { Context, Config } from './interfaces';
 import * as db from './db';
 import * as team from './team';
-import * as log from 'fancy-log'
+import * as log from './logger'
 
 /**
  * Checks permissions for group and admin.

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -1,23 +1,19 @@
 import { Context, Config } from './interfaces';
 import * as db from './db';
+import * as team from './team';
 import * as log from 'fancy-log'
 
 /**
  * Checks permissions for group and admin.
- *
- * @param ctx - Bot context.
- * @param config - Configuration containing categories and staffchat_id.
- * @returns A promise that resolves to true if permission is granted, otherwise false.
  */
 async function checkRights(
   ctx: Context,
-  config: { categories: any[]; staffchat_id: any },
+  config: { categories: Array<{ group_id: number | string; name?: string; subgroups?: Array<{ group_id: number | string; name: string }> }>; staffchat_id: string | number },
 ): Promise<boolean> {
   const { categories, staffchat_id } = config;
 
   if (categories) {
     for (const category of categories) {
-      // If there are no subgroups, check directly.
       if (!category.subgroups) {
         if (category.group_id === ctx.chat.id) {
           ctx.session.groupAdmin = category.name;
@@ -35,7 +31,6 @@ async function checkRights(
     }
   }
 
-  // If in a private chat, clear any group admin assignment.
   if (ctx.session.groupAdmin && ctx.chat.type === 'private') {
     ctx.session.groupAdmin = undefined;
   }
@@ -50,10 +45,7 @@ async function checkRights(
 
 /**
  * Defines user permissions by checking group/admin rights and ban status.
- *
- * @param ctx - Bot context.
- * @param next - Next function to call if permission checks pass.
- * @param config - Configuration settings.
+ * Also initializes staff role cache.
  */
 async function checkPermissions(ctx: Context, next: () => any, config: Config) {
   ctx.session.admin = false;
@@ -61,16 +53,19 @@ async function checkPermissions(ctx: Context, next: () => any, config: Config) {
     const access = await checkRights(ctx, config);
     if (access) {
       ctx.session.admin = true;
+      const role = team.getStaffRole(ctx.from.id.toString());
+      if (role) {
+        ctx.session.staffRole = role;
+      }
     }
   } catch (error) {
     log.error('Error checking rights:', error);
   } finally {
-    db.checkBan(ctx.chat.id, ctx.messenger, (ticket) => {
-      if (ticket && ticket.status === 'banned') {
-        return;
-      }
-      return next();
-    });
+    const ticket = await db.checkBan(ctx.chat.id, ctx.messenger);
+    if (ticket && ticket.status === 'banned') {
+      return;
+    }
+    next();
   }
 }
 

--- a/src/recovery.ts
+++ b/src/recovery.ts
@@ -1,5 +1,5 @@
 import cache from './cache';
-import * as log from 'fancy-log';
+import * as log from './logger';
 
 /**
  * Runs startup recovery to establish a resilient ticket ID baseline.

--- a/src/recovery.ts
+++ b/src/recovery.ts
@@ -1,0 +1,39 @@
+import cache from './cache';
+import * as log from 'fancy-log';
+
+/**
+ * Runs startup recovery to establish a resilient ticket ID baseline.
+ *
+ * Note: Telegram Bot API cannot fetch chat history (that requires MTProto/TDLib).
+ * Instead, we rely on MongoDB's stored max ticketId and use atomic increments
+ * to prevent collisions even if the DB is partially lost or reset.
+ */
+export async function runRecovery(): Promise<void> {
+  const dbMax = await getMaxDbTicketId();
+
+  cache.recoveryBaseline = dbMax;
+
+  log.info(
+    `Recovery: DB max=#T${dbMax} → baseline set to #T${cache.recoveryBaseline}`,
+  );
+
+  if (dbMax === 0) {
+    log.info('Recovery: No existing tickets found in DB — will start from #T000001');
+  }
+}
+
+/**
+ * Returns the highest ticketId currently in MongoDB.
+ */
+async function getMaxDbTicketId(): Promise<number> {
+  const { Supportee } = await import('./db.js');
+  try {
+    const lastEntry = await (Supportee as any).findOne()
+      .sort({ ticketId: -1 })
+      .select('ticketId');
+    return lastEntry ? lastEntry.ticketId : 0;
+  } catch (err) {
+    log.error('Recovery: Failed to query DB for max ticket ID:', err);
+    return 0;
+  }
+}

--- a/src/staff.ts
+++ b/src/staff.ts
@@ -3,7 +3,7 @@ import * as middleware from './middleware';
 import * as db from './db';
 import { Context } from './interfaces';
 import { ISupportee } from './db';
-import * as log from 'fancy-log'
+import * as log from './logger'
 import * as webhooks from './webhooks';
 import * as analytics from './analytics';
 import * as team from './team';

--- a/src/staff.ts
+++ b/src/staff.ts
@@ -5,6 +5,8 @@ import { Context } from './interfaces';
 import { ISupportee } from './db';
 import * as log from 'fancy-log'
 
+const escapeRegex = (str: string): string => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
 /**
  * Generates a ticket message.
  *
@@ -46,22 +48,14 @@ function privateReply(ctx: Context, msg: any = {}) {
     ticketMsg(`${modeData.name}`, msg),
     {
       parse_mode: cache.config.parse_mode,
-      reply_markup: {
-        html: '',
-        inline_keyboard: [
-          [
-            cache.config.direct_reply
-              ? {
-                text: cache.config.language.replyPrivate,
-                url: `https://t.me/${from.username}`,
-              }
-              : {
-                text: cache.config.language.replyPrivate,
-                callback_data: `${from.id}---${message.from.first_name}---${modeData.category}---${modeData.ticketid}`,
-              },
+      reply_markup: cache.config.direct_reply
+        ? {
+          html: '',
+          inline_keyboard: [
+            [{ text: cache.config.language.replyPrivate, url: `https://t.me/${from.username}` }],
           ],
-        ],
-      },
+        }
+        : middleware.buildInlineKeyboard(from.id, message.from.first_name, modeData.category, modeData.ticketid),
     },
   );
   // Send confirmation message
@@ -74,11 +68,11 @@ function privateReply(ctx: Context, msg: any = {}) {
  * @param replyText - The text from which to extract the ticket ID.
  * @returns The extracted ticket ID or null if not found.
  */
-function extractTicketId(replyText: string, ctx: Context): string | null {
+function extractTicketId(replyText: string): string | null {
   const { language } = cache.config;
-  let match = replyText.match(new RegExp(`#T(.*) ${language.from}`));
+  let match = replyText.match(new RegExp(`#T(.*) ${escapeRegex(language.from)}`));
   if (!match) {
-    match = replyText.match(new RegExp(`#T(.*)\n${language.from}`));
+    match = replyText.match(new RegExp(`#T(.*)\\n${escapeRegex(language.from)}`));
   }
   return match ? match[1].trim() : null;
 }
@@ -91,7 +85,7 @@ function extractTicketId(replyText: string, ctx: Context): string | null {
  */
 function extractName(replyText: string): string | null {
   const { language } = cache.config;
-  const match = replyText.match(new RegExp(`${language.from} (.*) ${language.language}`));
+  const match = replyText.match(new RegExp(`${escapeRegex(language.from)} (.*) ${escapeRegex(language.language)}`));
   return match ? match[1].trim() : null;
 }
 
@@ -112,16 +106,17 @@ async function chat(ctx: Context) {
   const replyMessageId = ctx.message.external_reply?.message_id;
   if (!replyText && !replyMessageId) return;
 
-  var ticket;
-  var ticketId;
+  let ticket: ISupportee | null;
+  let ticketId: number;
   if (replyMessageId) {
     ticket = await db.getTicketByInternalId(replyMessageId);
     if (ticket) {
       ticketId = ticket.ticketId;
     }
   } else {
-    ticketId = parseInt(await extractTicketId(replyText, ctx));
-    
+    const extractedId = extractTicketId(replyText);
+    if (!extractedId) return;
+    ticketId = parseInt(extractedId);
     if (!ticketId) return;
     ticket = await db.getTicketById(ticketId, ctx.session.groupCategory);
   }
@@ -130,7 +125,7 @@ async function chat(ctx: Context) {
     middleware.reply(ctx, cache.config.language.ticketClosedError);
     return;
   }
-  var name;
+  let name: string | null;
   if (ticket.name) {
     name = ticket.name;
   } else {

--- a/src/staff.ts
+++ b/src/staff.ts
@@ -4,6 +4,9 @@ import * as db from './db';
 import { Context } from './interfaces';
 import { ISupportee } from './db';
 import * as log from 'fancy-log'
+import * as webhooks from './webhooks';
+import * as analytics from './analytics';
+import * as team from './team';
 
 const escapeRegex = (str: string): string => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
@@ -57,9 +60,9 @@ function privateReply(ctx: Context, msg: any = {}) {
         }
         : middleware.buildInlineKeyboard(from.id, message.from.first_name, modeData.category, modeData.ticketid),
     },
-  );
+  ).catch(log.error);
   // Send confirmation message
-  middleware.sendMessage(chat.id, messenger, cache.config.language.msg_sent, {});
+  middleware.sendMessage(chat.id, messenger, cache.config.language.msg_sent, {}).catch(log.error);
 }
 
 /**
@@ -75,6 +78,25 @@ function extractTicketId(replyText: string): string | null {
     match = replyText.match(new RegExp(`#T(.*)\\n${escapeRegex(language.from)}`));
   }
   return match ? match[1].trim() : null;
+}
+
+/**
+ * Extracts the supportee's Telegram user ID from a forwarded ticket message.
+ * Handles both MarkdownV2/HTML link formats and plain text fallback.
+ *
+ * @param replyText - The original forwarded ticket message text.
+ * @returns The extracted user ID or null if not found.
+ */
+function extractSupporteeId(replyText: string): string | null {
+  // Try to extract from tg://user?id=<id> link (MarkdownV2 / HTML format)
+  const linkMatch = replyText.match(/tg:\/\/user\?id=(\d+)/);
+  if (linkMatch) return linkMatch[1];
+
+  // Fallback: try [name](tg://user?id=<id>) Markdown pattern
+  const mdMatch = replyText.match(/\[.*?\]\(tg:\/\/user\?id=(\d+)\)/);
+  if (mdMatch) return mdMatch[1];
+
+  return null;
 }
 
 /**
@@ -106,22 +128,38 @@ async function chat(ctx: Context) {
   const replyMessageId = ctx.message.external_reply?.message_id;
   if (!replyText && !replyMessageId) return;
 
-  let ticket: ISupportee | null;
-  let ticketId: number;
+  let ticket: ISupportee | null = null;
+  let ticketId: number = 0;
   if (replyMessageId) {
     ticket = await db.getTicketByInternalId(replyMessageId);
     if (ticket) {
       ticketId = ticket.ticketId;
     }
-  } else {
-    const extractedId = extractTicketId(replyText);
-    if (!extractedId) return;
-    ticketId = parseInt(extractedId);
-    if (!ticketId) return;
-    ticket = await db.getTicketById(ticketId, ctx.session.groupCategory);
   }
 
-  if (!ticket) {
+  // If internal ID lookup failed, try regex extraction from text
+  if (!ticket && replyText) {
+    const extractedId = extractTicketId(replyText);
+    if (extractedId) {
+      ticketId = parseInt(extractedId, 10);
+      if (ticketId) {
+        ticket = await db.getTicketById(ticketId, ctx.session.groupCategory);
+      }
+    }
+  }
+
+  // If regex also failed, try to find the supportee by extracting their Telegram ID from the forwarded message
+  if (!ticket && replyText) {
+    const supporteeId = extractSupporteeId(replyText);
+    if (supporteeId) {
+      ticket = await db.getTicketByUserId(supporteeId, ctx.session.groupCategory);
+      if (ticket) {
+        ticketId = ticket.ticketId;
+      }
+    }
+  }
+
+  if (!ticket || !ticketId) {
     middleware.reply(ctx, cache.config.language.ticketClosedError);
     return;
   }
@@ -133,8 +171,25 @@ async function chat(ctx: Context) {
   }
   if (!name) return;
 
+  // Check for internal note prefix (!note or !internal)
+  const staffMessage = ctx.message.text || '';
+  if (staffMessage.startsWith('!note ') || staffMessage.startsWith('!internal ')) {
+    const noteText = staffMessage.replace(/^!(?:note|internal)\s+/i, '');
+    await team.addInternalNoteCommand(ctx, ticketId, noteText);
+    return;
+  }
+
   // Mark ticket as no longer active
   cache.ticketStatus[ticketId] = false;
+
+  // Set first response time if not already set
+  if (!ticket.first_response_at) {
+    await db.setFirstResponseAt(ticketId);
+  }
+
+  // Log conversation memory
+  const senderId = ctx.from.id.toString();
+  await db.addTicketMessage(ticketId, 'staff', senderId, staffMessage);
 
   // Reply to web users differently
   if (ticket.userid.includes('WEB')) {
@@ -146,25 +201,46 @@ async function chat(ctx: Context) {
         ctx.chat.id,
         ticket.messenger,
         `Web chat already closed.`,
-      );
+      ).catch(log.error);
       log.error(e);
     }
   } else {
-    middleware.sendMessage(ticket.userid, ticket.messenger, ticketMsg(name, ctx.message));
+    // Apply translation if enabled
+    let replyContent = ticketMsg(name, ctx.message);
+    if (cache.config.translate_enabled) {
+      const translated = await import('./addons/llm.js').then(m => m.translateText(staffMessage));
+      if (translated) {
+        replyContent = ticketMsg(name, { text: translated, from: ctx.message.from });
+      }
+    }
+    middleware.sendMessage(ticket.userid, ticket.messenger, replyContent).catch(log.error);
   }
+
   const esc = middleware.strictEscape;
   middleware.sendMessage(
     ctx.chat.id,
     cache.config.staffchat_type,
     `${cache.config.language.msg_sent} ${esc(name)}`,
-  );
+  ).catch(log.error);
   log.info(`Answer: ${ticketMsg(name, ctx.message)}`);
-  cache.ticketSent[ticketId] = null;
+  delete cache.ticketSent[ticketId];
+
+  // Record analytics event for staff reply
+  await db.recordAnalyticsEvent('staff_reply', ticketId, senderId);
+
+  // Fire webhook for ticket reply
+  await webhooks.webhooks.ticketReplied(ticketId, senderId, staffMessage.substring(0, 200));
 
   // Auto-close the ticket if enabled
   if (cache.config.auto_close_tickets) {
-      db.add(ticketId, 'closed', null, ticket.messenger);
+    await db.add(String(ticketId), 'closed', '', ticket.messenger);
+    await db.setClosedAt(ticketId);
+    await db.recordAnalyticsEvent('ticket_closed', ticketId, senderId);
+    await webhooks.webhooks.ticketClosed(ticketId, senderId.toString());
+
+    // Send CSAT survey on close
+    await analytics.sendCSATSurvey(ticket.userid, ticket.messenger, ticketId);
   }
 }
 
-export { privateReply, chat, ticketMsg };
+export { privateReply, chat, ticketMsg, extractSupporteeId };

--- a/src/team.ts
+++ b/src/team.ts
@@ -2,7 +2,7 @@ import { Context } from './interfaces';
 import cache from './cache';
 import * as db from './db';
 import * as middleware from './middleware';
-import * as log from 'fancy-log'
+import * as log from './logger'
 
 /**
  * Initializes staff member cache from config on startup.

--- a/src/team.ts
+++ b/src/team.ts
@@ -1,0 +1,199 @@
+import { Context } from './interfaces';
+import cache from './cache';
+import * as db from './db';
+import * as middleware from './middleware';
+import * as log from 'fancy-log'
+
+/**
+ * Initializes staff member cache from config on startup.
+ */
+export function initStaffCache(): void {
+    const staffRoles = cache.config.staff_roles || [];
+    cache.staffMembers = new Map();
+    cache.mutedTickets = new Set();
+
+    for (const member of staffRoles) {
+        cache.staffMembers.set(member.telegram_id, member);
+    }
+
+    log.info(`Loaded ${cache.staffMembers.size} staff members from config.`);
+}
+
+/**
+ * Gets the role of a staff member by their Telegram ID.
+ */
+export function getStaffRole(telegramId: string): 'admin' | 'supervisor' | 'agent' | null {
+    const member = cache.staffMembers.get(telegramId);
+    if (!member) return null;
+    return member.role as 'admin' | 'supervisor' | 'agent';
+}
+
+/**
+ * Checks if a user has permission to perform an action.
+ */
+export function canPerformAction(
+    telegramId: string,
+    action: 'reply' | 'assign' | 'view_analytics' | 'manage_team',
+): boolean {
+    const role = getStaffRole(telegramId);
+
+    switch (action) {
+        case 'reply':
+            return ['admin', 'supervisor', 'agent'].includes(role || '');
+        case 'assign':
+            return ['admin', 'supervisor'].includes(role || '');
+        case 'view_analytics':
+            return ['admin', 'supervisor'].includes(role || '');
+        case 'manage_team':
+            return role === 'admin';
+        default:
+            return false;
+    }
+}
+
+/**
+ * Assigns a ticket to a specific staff member.
+ */
+export async function assignTicketCommand(ctx: Context, targetId: string, ticketId: number): Promise<void> {
+    const role = getStaffRole(targetId);
+    if (!role) {
+        middleware.reply(ctx, `User ${targetId} is not a registered staff member.`);
+        return;
+    }
+
+    await db.assignTicket(ticketId, targetId);
+
+    const member = cache.staffMembers.get(targetId);
+    const memberName = member?.name || targetId;
+    middleware.reply(ctx, `${cache.config.language.ticketAssignedTo} ${memberName}`);
+
+    // Notify the assigned agent
+    if (targetId !== ctx.from.id) {
+        middleware.sendMessage(
+            targetId,
+            cache.config.staffchat_type,
+            `📋 You have been assigned ticket #T${ticketId.toString().padStart(6, '0')} by ${ctx.message?.from?.first_name || 'staff'}.`,
+            { parse_mode: cache.config.parse_mode },
+        ).catch(log.error);
+    }
+
+    await db.recordAnalyticsEvent('ticket.assigned', ticketId, targetId, { assigned_by: ctx.from.id });
+}
+
+/**
+ * Unassigns a ticket from its current assignee.
+ */
+export async function unassignTicketCommand(ctx: Context, ticketId: number): Promise<void> {
+    await db.unassignTicket(ticketId);
+    middleware.reply(ctx, cache.config.language.ticketUnassigned);
+}
+
+/**
+ * Adds tags to a ticket.
+ */
+export async function addTagsCommand(ctx: Context, ticketId: number, tags: string[]): Promise<void> {
+    await db.addTags(ticketId, tags);
+    middleware.reply(ctx, `Tags added: ${tags.join(', ')}`);
+}
+
+/**
+ * Removes a tag from a ticket.
+ */
+export async function removeTagCommand(ctx: Context, ticketId: number, tag: string): Promise<void> {
+    await db.removeTag(ticketId, tag);
+    middleware.reply(ctx, `Tag removed: ${tag}`);
+}
+
+/**
+ * Sets the priority of a ticket.
+ */
+export async function setPriorityCommand(
+    ctx: Context,
+    ticketId: number,
+    priority: 'low' | 'normal' | 'high' | 'urgent',
+): Promise<void> {
+    await db.setPriority(ticketId, priority as any);
+
+    const icons: Record<string, string> = { urgent: '🔴', high: '🟠', normal: '🟡', low: '⚪' };
+    middleware.reply(ctx, `${icons[priority]} Priority set to ${priority.toUpperCase()}`);
+}
+
+/**
+ * Mutes notifications for a ticket.
+ */
+export async function muteTicketCommand(ctx: Context, ticketId: number): Promise<void> {
+    cache.mutedTickets.add(ticketId.toString());
+    middleware.reply(ctx, `🔇 Ticket #T${ticketId.toString().padStart(6, '0')} muted.`);
+}
+
+/**
+ * Unmutes notifications for a ticket.
+ */
+export async function unmuteTicketCommand(ctx: Context, ticketId: number): Promise<void> {
+    cache.mutedTickets.delete(ticketId.toString());
+    middleware.reply(ctx, `🔊 Ticket #T${ticketId.toString().padStart(6, '0')} unmuted.`);
+}
+
+/**
+ * Adds an internal note to a ticket (not forwarded to user).
+ */
+export async function addInternalNoteCommand(ctx: Context, ticketId: number, text: string): Promise<void> {
+    await db.addInternalNote(ticketId, ctx.from.id.toString(), text);
+
+    // Show note in staff chat
+    const esc = middleware.strictEscape;
+    middleware.sendMessage(
+        cache.config.staffchat_id,
+        cache.config.staffchat_type,
+        `📝 ${cache.config.language.internalNote} #T${ticketId.toString().padStart(6, '0')} (${cache.config.language.noteAddedBy} ${esc(ctx.message?.from?.first_name || 'staff')}):\n${esc(text)}`,
+        { parse_mode: cache.config.parse_mode },
+    ).catch(log.error);
+
+    await db.recordAnalyticsEvent('internal_note', ticketId, ctx.from.id.toString());
+}
+
+/**
+ * Shows all internal notes for a ticket.
+ */
+export async function showNotesCommand(ctx: Context, ticketId: number): Promise<void> {
+    const notes = await db.getInternalNotes(ticketId);
+    if (notes.length === 0) {
+        middleware.reply(ctx, `No internal notes for ticket #T${ticketId.toString().padStart(6, '0')}.`);
+        return;
+    }
+
+    const esc = middleware.strictEscape;
+    let output = `📝 ${cache.config.language.internalNote} #T${ticketId.toString().padStart(6, '0')}:\n\n`;
+    for (const note of notes) {
+        const author = cache.staffMembers.get(note.author_id);
+        const authorName = author?.name || note.author_id;
+        output += `• [${authorName}] ${esc(note.text)}\n`;
+    }
+
+    middleware.reply(ctx, output.trim());
+}
+
+/**
+ * Lists all staff members and their roles.
+ */
+export async function listStaffCommand(ctx: Context): Promise<void> {
+    if (cache.staffMembers.size === 0) {
+        middleware.reply(ctx, 'No staff members configured.');
+        return;
+    }
+
+    let output = '👥 *Staff Members*:\n\n';
+    for (const [id, member] of cache.staffMembers) {
+        const roleIcons: Record<string, string> = { admin: '👑', supervisor: '⭐', agent: '🔧' };
+        output += `${roleIcons[member.role] || ''} ${member.name} (${member.role})\n`;
+    }
+
+    middleware.reply(ctx, output.trim(), { parse_mode: cache.config.parse_mode });
+}
+
+/**
+ * Checks if a ticket is muted (no notifications should be sent).
+ */
+export function isTicketMuted(ticketId: number): boolean {
+    return cache.mutedTickets.has(ticketId.toString());
+}

--- a/src/text.ts
+++ b/src/text.ts
@@ -67,14 +67,14 @@ export async function ticketHandler(bot: Addon, ctx: Context): Promise<ISupporte
   const { chat, message, session, messenger } = ctx;
   // For private chats, check for an existing ticket; otherwise, create one.
   if (chat.type === 'private') {
-    const ticket = await db.getTicketByUserId(message.from.id, session.groupCategory)
+    const ticket = await db.getTicketByUserId(message.from.id, session.groupCategory);
     if (!ticket) {
-      db.add(message.from.id, 'open', session.groupCategory, messenger);
+      await db.add(message.from.id, 'open', session.groupCategory, messenger);
     }
-    users.chat(ctx, message.chat);
+    await users.chat(ctx, message.chat);
     return ticket;
   }
 
   // For non-private chats, use the staff chat handler.
-  staff.chat(ctx);
+  await staff.chat(ctx);
 }

--- a/src/text.ts
+++ b/src/text.ts
@@ -40,21 +40,23 @@ const shouldReplyWithCategoryKeyboard = (ctx: Context): boolean => {
  * @param ctx - The context of the message.
  * @param keys - Keyboard keys to use for replies.
  */
-export function handleText(bot: Addon, ctx: Context, keys: any[] = []) {
+export async function handleText(bot: Addon, ctx: Context, keys: string[][] = []): Promise<void> {
   // Handle private replies via staff
   if (ctx.session.mode === 'private_reply') {
-    return staff.privateReply(ctx);
+    await staff.privateReply(ctx);
+    return;
   }
 
   // If conditions met, reply with the category keyboard
   if (shouldReplyWithCategoryKeyboard(ctx)) {
-    return middleware.reply(ctx, cache.config.language.services, {
+    await middleware.reply(ctx, cache.config.language.services, {
       reply_markup: { keyboard: keys },
     });
+    return;
   }
 
   // In all other cases, process the ticket
-  return ticketHandler(bot, ctx);
+  await ticketHandler(bot, ctx);
 }
 
 /**
@@ -77,4 +79,5 @@ export async function ticketHandler(bot: Addon, ctx: Context): Promise<ISupporte
 
   // For non-private chats, use the staff chat handler.
   await staff.chat(ctx);
+  return null;
 }

--- a/src/triage.ts
+++ b/src/triage.ts
@@ -2,7 +2,7 @@ import { Context } from './interfaces';
 import OpenAI from 'openai';
 import cache from './cache';
 import * as db from './db';
-import * as log from 'fancy-log'
+import * as log from './logger'
 
 // Lazy-initialize OpenAI client to avoid issues when config isn't loaded (e.g., tests)
 let llm: InstanceType<typeof OpenAI> | null = null;

--- a/src/triage.ts
+++ b/src/triage.ts
@@ -1,0 +1,133 @@
+import { Context } from './interfaces';
+import OpenAI from 'openai';
+import cache from './cache';
+import * as db from './db';
+import * as log from 'fancy-log'
+
+// Lazy-initialize OpenAI client to avoid issues when config isn't loaded (e.g., tests)
+let llm: InstanceType<typeof OpenAI> | null = null;
+function getLLM(): InstanceType<typeof OpenAI> {
+    if (!llm) {
+        llm = new OpenAI({
+            apiKey: cache.config.llm_api_key,
+            baseURL: cache.config.llm_base_url,
+        });
+    }
+    return llm;
+}
+
+export interface TriageResult {
+    category: string | null;
+    priority: 'low' | 'normal' | 'high' | 'urgent';
+    summary: string;
+    sentimentScore: number; // 1-5, 1 = very negative, 5 = positive
+}
+
+/**
+ * Analyzes an incoming user message to classify category, priority, and sentiment.
+ * Returns a structured triage result.
+ */
+export async function analyzeMessage(
+    text: string,
+    ticketId?: number,
+): Promise<TriageResult | null> {
+    if (!cache.config.auto_triage) return null;
+
+    const categories = cache.config.categories || [];
+    const categoryList = categories.map((c: any) => c.name).join(', ') || 'General';
+
+    const systemPrompt = `You are a support ticket triage assistant. Analyze the customer message and return ONLY valid JSON with this exact structure:
+{
+  "category": "<one of: ${categoryList}, or null if unclear>",
+  "priority": "<low, normal, high, or urgent>",
+  "summary": "<brief one-line summary of the issue>",
+  "sentimentScore": <number 1-5, where 1=very angry/frustrated, 3=neutral, 5=happy/satisfied>
+}
+
+Rules:
+- Priority should be 'urgent' for complaints about outages, data loss, billing errors, or threats to leave.
+- Priority should be 'high' for bugs affecting core functionality or repeated issues.
+- Priority should be 'normal' for general questions and feature requests.
+- Priority should be 'low' for minor suggestions or compliments.
+- Sentiment score: 1 = very angry/threatening, 2 = frustrated/complaining, 3 = neutral, 4 = positive, 5 = very happy/grateful`;
+
+    try {
+        const response = await getLLM().chat.completions.create({
+            model: cache.config.llm_model || 'gpt-3.5-turbo',
+            messages: [
+                { role: "system", content: systemPrompt },
+                { role: "user", content: text },
+            ],
+        });
+
+        const raw = response.choices[0]?.message?.content;
+        if (!raw) return null;
+
+        // Parse JSON from response (handle markdown code blocks)
+        let jsonStr = raw.trim();
+        if (jsonStr.startsWith('```')) {
+            jsonStr = jsonStr.replace(/```json?\n?/g, '').replace(/```\s*$/g, '');
+        }
+
+        const parsed: TriageResult = JSON.parse(jsonStr);
+
+        // Validate and set defaults
+        if (!['low', 'normal', 'high', 'urgent'].includes(parsed.priority)) {
+            parsed.priority = 'normal';
+        }
+        if (parsed.sentimentScore < 1) parsed.sentimentScore = 1;
+        if (parsed.sentimentScore > 5) parsed.sentimentScore = 5;
+
+        // Store triage result in DB
+        if (ticketId) {
+            await db.setTriageInfo(
+                ticketId,
+                parsed.category,
+                parsed.summary,
+                parsed.sentimentScore,
+            );
+        }
+
+        return parsed;
+    } catch (error) {
+        log.error("Error in triage analysis:", error);
+        return null;
+    }
+}
+
+/**
+ * Formats the triage result as a prefix string to prepend to staff ticket messages.
+ */
+export function formatTriagePrefix(triage: TriageResult): string {
+    if (!triage) return '';
+
+    let prefix = '';
+
+    // Sentiment alert
+    const threshold = cache.config.sentiment_alert_threshold || 2;
+    if (triage.sentimentScore <= threshold) {
+        prefix += `${cache.config.language.sentimentAlert}\n`;
+    }
+
+    // Priority indicator
+    const priorityIcons: Record<string, string> = {
+        urgent: '🔴',
+        high: '🟠',
+        normal: '🟡',
+        low: '⚪',
+    };
+    const icon = priorityIcons[triage.priority] || '🟡';
+    prefix += `${icon} ${cache.config.language.triagePriority}: ${triage.priority.toUpperCase()}\n`;
+
+    // Category
+    if (triage.category) {
+        prefix += `📂 ${cache.config.language.triageSummary}: ${triage.category}\n`;
+    }
+
+    // Summary
+    if (triage.summary) {
+        prefix += `📝 ${triage.summary}\n`;
+    }
+
+    return prefix ? `\n${prefix}\n` : '';
+}

--- a/src/users.ts
+++ b/src/users.ts
@@ -5,16 +5,17 @@ import * as db from './db';
 import { buildInlineKeyboard, strictEscape as esc, reply, sendMessage } from './middleware';
 import { ISupportee } from './db';
 import * as log from 'fancy-log'
+import * as triage from './triage';
+import * as webhooks from './webhooks';
+import * as workflows from './workflows';
 
 const TIME_BETWEEN_CONFIRMATION_MESSAGES = 86400000; // 24 hours
 
 /**
- * Generates a ticket message.
+ * Generates a ticket message with triage prefix and priority indicators.
  *
  * @param ticket - Ticket object with a toString() method.
- * @param message - Message object containing text and sender info.
- * @param tag - Tag string.
- * @param anonymousUser - Whether the ticket is anonymous (default: true).
+ * @param ctx - Bot context.
  * @param autoReplyInfo - Optional auto-reply info to append.
  * @returns The formatted ticket message.
  */
@@ -28,9 +29,32 @@ function formatMessageAsTicket(
   if (config.anonymous_tickets || config.staffchat_parse_mode === ParseMode.PLAINTEXT) {
     name = ctx.message.from.first_name;
   }
-  return `${config.language.ticket} #T${ticket
+
+  // Priority indicator prefix
+  const priorityIcons: Record<string, string> = { urgent: '🔴', high: '🟠', normal: '🟡', low: '⚪' };
+  const ticketObj = (ctx.session as any).ticketData;
+  let priorityPrefix = '';
+  if (ticketObj && ticketObj.priority && ticketObj.priority !== 'normal') {
+    priorityPrefix = `${priorityIcons[ticketObj.priority] || ''} `;
+  }
+
+  // Assignment info prefix
+  let assignPrefix = '';
+  if (ticketObj && ticketObj.assigned_to) {
+    const assignedMember = cache.staffMembers?.get(ticketObj.assigned_to);
+    const assignName = assignedMember?.name || ticketObj.assigned_to;
+    assignPrefix = `📋 Assigned: ${assignName}\n`;
+  }
+
+  // Tags prefix
+  let tagsPrefix = '';
+  if (ticketObj && ticketObj.tags && ticketObj.tags.length > 0) {
+    tagsPrefix = `🏷️ ${ticketObj.tags.map((t: string) => `#${t}`).join(' ')}\n`;
+  }
+
+  return `${priorityPrefix}${config.language.ticket} #T${ticket
     .toString()
-    .padStart(6, '0')} ${config.language.from} ${name} ${config.language.language}: ${ctx.message.from.language_code} ${ctx.session.groupTag}\n\n${esc(
+    .padStart(6, '0')} ${config.language.from} ${name} ${config.language.language}: ${ctx.message.from.language_code} ${ctx.session.groupTag}\n\n${assignPrefix}${tagsPrefix}${esc(
       ctx.message.text,
     )}\n\n${autoReplyInfo ? `*${autoReplyInfo}*` : ''}`;
 }
@@ -85,6 +109,7 @@ async function autoReply(ctx: Context): Promise<boolean> {
 
 /**
  * Processes a ticket by sending confirmation and forwarding it to staff and group chats.
+ * Integrates triage analysis, conversation memory logging, and webhook events.
  *
  * @param ticket - The ticket retrieved from the database.
  * @param ctx - Bot context.
@@ -98,6 +123,51 @@ async function processTicket(
   autoReplyInfo?: string,
 ) {
   const { config } = cache;
+
+  // Store ticket data on session for formatting (priority, assignment, tags)
+  (ctx.session as any).ticketData = {
+    priority: ticket.priority,
+    assigned_to: ticket.assigned_to,
+    tags: ticket.tags || [],
+  };
+
+  // Run AI triage analysis on new tickets
+  if (!autoReplyInfo && config.auto_triage) {
+    const userText = ctx.message.text;
+    await triage.analyzeMessage(userText, ticket.ticketId);
+
+    // Refresh ticket data with triage results
+    const refreshedTicket = await db.getTicketById(ticket.ticketId, ctx.session.groupCategory);
+    if (refreshedTicket) {
+      (ctx.session as any).ticketData = {
+        priority: refreshedTicket.priority,
+        assigned_to: refreshedTicket.assigned_to,
+        tags: refreshedTicket.tags || [],
+      };
+
+      // Add triage prefix to the message for staff
+      const triagePrefix = triage.formatTriagePrefix({
+        category: refreshedTicket.triage_category,
+        priority: refreshedTicket.priority as import('./interfaces').TicketPriority,
+        summary: refreshedTicket.triage_summary || '',
+        sentimentScore: refreshedTicket.sentiment_score || 3,
+      });
+      if (triagePrefix) {
+        // Prepend triage info to the formatted message by modifying context temporarily
+        ctx.message.text = triagePrefix + ctx.message.text;
+      }
+    }
+  }
+
+  // Log conversation memory
+  await db.addTicketMessage(ticket.ticketId, 'user', ctx.from.id.toString(), ctx.message.text);
+
+  // Fire webhook for ticket creation (only on first message)
+  if (!autoReplyInfo) {
+    await webhooks.webhooks.ticketCreated(ticket.ticketId, ctx.from.id.toString(), ctx.message.text.substring(0, 200));
+    await db.recordAnalyticsEvent('ticket_created', ticket.ticketId, null);
+  }
+
   // Send confirmation if applicable
   if (
     !autoReplyInfo &&
@@ -112,7 +182,7 @@ async function processTicket(
       (config.show_user_ticket
         ? `${config.language.ticket} #T${ticket.ticketId.toString().padStart(6, '0')}`
         : '');
-    sendMessage(chatId, ticket.messenger, confirmationMsg);
+    sendMessage(chatId, ticket.messenger, confirmationMsg).catch(log.error);
   }
 
   // Send ticket message to staff chat
@@ -125,7 +195,9 @@ async function processTicket(
       autoReplyInfo,
     ),
   );
-  db.addIdAndName(ticket.ticketId, messageId, ctx.message.from.first_name);
+  if (messageId) {
+    db.addIdAndName(ticket.ticketId, messageId, ctx.message.from.first_name);
+  }
 
   // If group flag is set and not the admin chat, forward to group chat
   if (ctx.session.group && ctx.session.group !== config.staffchat_id) {
@@ -145,18 +217,26 @@ async function processTicket(
         autoReplyInfo,
       ),
       groupOptions,
-    );
+    ).catch(log.error);
   }
-};
+}
 
 /**
- * Handles ticket processing with spam protection.
+ * Handles ticket processing with spam protection and business hours check.
  *
  * @param ctx - Bot context.
  * @param chat - Chat object containing an id.
  */
 async function chat(ctx: Context, chat: { id: string }) {
   const { config } = cache;
+
+  // Check business hours — if outside hours, send offline message and skip processing
+  if (!workflows.isWithinBusinessHours()) {
+    const offlineMsg = config.language.businessHoursClosed || 'Our support team is currently offline. We will respond during business hours.';
+    reply(ctx, offlineMsg);
+    return;
+  }
+
   cache.userId = ctx.message.from.id;
   const isAutoReply = await autoReply(ctx);
   if (isAutoReply && !config.show_auto_replied) return;
@@ -164,23 +244,27 @@ async function chat(ctx: Context, chat: { id: string }) {
 
   // Ensure the user's ticket is tracked
   if (cache.ticketIDs[cache.userId] === undefined) {
-    cache.ticketIDs.push(cache.userId);
+    cache.ticketIDs[cache.userId] = cache.userId;
   }
   cache.ticketStatus[cache.userId] = true;
 
   // If no ticket has been sent yet, fetch from DB and set up spam timer
-  if (cache.ticketSent[cache.userId] === undefined) {
+  const sentCount = cache.ticketSent[cache.userId];
+  if (sentCount === undefined) {
     const ticket = await db.getTicketByUserId(chat.id, ctx.session.groupCategory);
-    processTicket(ticket, ctx, chat.id, autoReplyInfo);
+    if (ticket) {
+      await processTicket(ticket, ctx, chat.id, autoReplyInfo);
+    }
 
     // Prevent multiple notifications for a period defined by spam_time
     setTimeout(() => {
-      cache.ticketSent[cache.userId] = undefined;
+      delete cache.ticketSent[cache.userId];
     }, config.spam_time);
     cache.ticketSent[cache.userId] = 0;
-  } else if (cache.ticketSent[cache.userId] < config.spam_cant_msg) {
-    cache.ticketSent[cache.userId]++;
+  } else if (sentCount < config.spam_cant_msg) {
+    cache.ticketSent[cache.userId] = sentCount + 1;
     const ticket = await db.getTicketByUserId(cache.userId, ctx.session.groupCategory);
+    if (!ticket) return;
     sendMessage(
       config.staffchat_id,
       config.staffchat_type,
@@ -189,7 +273,7 @@ async function chat(ctx: Context, chat: { id: string }) {
         ctx,
         autoReplyInfo,
       ),
-    );
+    ).catch(log.error);
     if (ctx.session.group && ctx.session.group !== config.staffchat_id) {
       sendMessage(
         ctx.session.group,
@@ -199,22 +283,24 @@ async function chat(ctx: Context, chat: { id: string }) {
           ctx,
           autoReplyInfo,
         ),
-      );
+      ).catch(log.error);
     }
-  } else if (cache.ticketSent[cache.userId] === config.spam_cant_msg) {
-    cache.ticketSent[cache.userId]++;
-    sendMessage(chat.id, ctx.messenger, config.language.blockedSpam);
+  } else if (sentCount === config.spam_cant_msg) {
+    cache.ticketSent[cache.userId] = sentCount + 1;
+    sendMessage(chat.id, ctx.messenger, config.language.blockedSpam).catch(log.error);
   }
 
   // Log the ticket message for debugging
-  const ticket = await db.getTicketByUserId(cache.userId, ctx.session.groupCategory)
-  log.info(
-    formatMessageAsTicket(
-      ticket.ticketId,
-      ctx,
-      autoReplyInfo,
-    ),
-  );
+  const logTicket = await db.getTicketByUserId(cache.userId, ctx.session.groupCategory);
+  if (logTicket) {
+    log.info(
+      formatMessageAsTicket(
+        logTicket.ticketId,
+        ctx,
+        autoReplyInfo,
+      ),
+    );
+  }
 }
 
 export { chat };

--- a/src/users.ts
+++ b/src/users.ts
@@ -2,7 +2,7 @@ import { Context, Messenger, ParseMode } from './interfaces';
 import cache from './cache';
 import * as llm from './addons/llm';
 import * as db from './db';
-import { strictEscape as esc, reply, sendMessage } from './middleware';
+import { buildInlineKeyboard, strictEscape as esc, reply, sendMessage } from './middleware';
 import { ISupportee } from './db';
 import * as log from 'fancy-log'
 
@@ -24,7 +24,7 @@ function formatMessageAsTicket(
   autoReplyInfo?: any,
 ): string {
   const { config, userId } = cache;
-  var name = `[${esc(ctx.message.from.first_name,)}](tg://user?id=${userId})`;
+  let name = `[${esc(ctx.message.from.first_name,)}](tg://user?id=${userId})`;
   if (config.anonymous_tickets || config.staffchat_parse_mode === ParseMode.PLAINTEXT) {
     name = ctx.message.from.first_name;
   }
@@ -132,24 +132,7 @@ async function processTicket(
     const groupOptions = config.allow_private
       ? {
         parse_mode: 'none',
-        reply_markup: {
-          html: '',
-          inline_keyboard: [
-            [
-              {
-                text: config.language.replyPrivate,
-                callback_data:
-                  ctx.from.id +
-                  '---' +
-                  ctx.message.from.first_name +
-                  '---' +
-                  ctx.session.groupCategory +
-                  '---' +
-                  ticket.ticketId,
-              },
-            ],
-          ],
-        },
+        reply_markup: buildInlineKeyboard(ctx.from.id, ctx.message.from.first_name, ctx.session.groupCategory, ticket.ticketId),
       }
       : { parse_mode: config.parse_mode };
 

--- a/src/users.ts
+++ b/src/users.ts
@@ -4,7 +4,7 @@ import * as llm from './addons/llm';
 import * as db from './db';
 import { buildInlineKeyboard, strictEscape as esc, reply, sendMessage } from './middleware';
 import { ISupportee } from './db';
-import * as log from 'fancy-log'
+import * as log from './logger'
 import * as triage from './triage';
 import * as webhooks from './webhooks';
 import * as workflows from './workflows';

--- a/src/webhooks.ts
+++ b/src/webhooks.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import cache from './cache';
-import * as log from 'fancy-log'
+import * as log from './logger'
 import { WebhookEvent } from './interfaces';
 
 export interface WebhookPayload {

--- a/src/webhooks.ts
+++ b/src/webhooks.ts
@@ -1,0 +1,89 @@
+import axios from 'axios';
+import cache from './cache';
+import * as log from 'fancy-log'
+import { WebhookEvent } from './interfaces';
+
+export interface WebhookPayload {
+    event: string;
+    ticket_id: number;
+    user_id: string | null;
+    timestamp: string;
+    message_preview?: string;
+    metadata?: Record<string, any>;
+}
+
+/**
+ * Sends a webhook event to all configured URLs that subscribe to the given event.
+ */
+export async function sendWebhook(
+    event: WebhookEvent | string,
+    ticketId: number,
+    userId: string | null = null,
+    messagePreview: string = '',
+    metadata: Record<string, any> = {},
+): Promise<void> {
+    const webhooks = cache.config.webhooks || [];
+    if (webhooks.length === 0) return;
+
+    const payload: WebhookPayload = {
+        event,
+        ticket_id: ticketId,
+        user_id: userId,
+        timestamp: new Date().toISOString(),
+        message_preview: messagePreview.substring(0, 200),
+        metadata,
+    };
+
+    for (const webhook of webhooks) {
+        if (!webhook.events.includes(event as WebhookEvent)) continue;
+
+        try {
+            const headers: Record<string, string> = {
+                'Content-Type': 'application/json',
+                'User-Agent': 'telegram-support-bot/5.0',
+            };
+
+            // Add HMAC signature if secret is configured
+            if (webhook.secret) {
+                const crypto = await import('crypto');
+                const sig = crypto.createHmac('sha256', webhook.secret)
+                    .update(JSON.stringify(payload))
+                    .digest('hex');
+                headers['X-TSB-Signature'] = sig;
+            }
+
+            await axios.post(webhook.url, payload, {
+                headers,
+                timeout: 5000,
+            });
+
+            log.info(`Webhook sent to ${webhook.url} for event ${event}`);
+        } catch (err) {
+            log.error(`Webhook failed for ${webhook.url}:`, err);
+        }
+    }
+}
+
+/**
+ * Convenience wrapper for common webhook events.
+ */
+export const webhooks = {
+    ticketCreated: async (ticketId: number, userId: string, messagePreview?: string) => {
+        await sendWebhook('ticket.created', ticketId, userId, messagePreview || '');
+    },
+    ticketReplied: async (ticketId: number, agentId: string, messagePreview?: string) => {
+        await sendWebhook('ticket.replied', ticketId, null, messagePreview || '', { agent_id: agentId });
+    },
+    ticketClosed: async (ticketId: number, userId: string) => {
+        await sendWebhook('ticket.closed', ticketId, userId);
+    },
+    ticketBanned: async (ticketId: number, userId: string) => {
+        await sendWebhook('ticket.banned', ticketId, userId);
+    },
+    csatRated: async (ticketId: number, rating: number, comment?: string) => {
+        await sendWebhook('csat.rated', ticketId, null, '', { rating, comment });
+    },
+    ticketEscalated: async (ticketId: number, reason: string) => {
+        await sendWebhook('ticket.escalated', ticketId, null, '', { reason });
+    },
+};

--- a/src/workflows.ts
+++ b/src/workflows.ts
@@ -1,0 +1,161 @@
+import cache from './cache';
+import * as db from './db';
+import * as middleware from './middleware';
+import { Context } from './interfaces';
+import * as log from 'fancy-log'
+
+/**
+ * Checks if the current time is within business hours.
+ */
+export function isWithinBusinessHours(): boolean {
+    const bh = cache.config.web_chat?.business_hours;
+    if (!bh || !bh.enabled) return true; // No business hours configured = always open
+
+    const now = new Date();
+    const timezone = bh.timezone || 'UTC';
+
+    // Get current time in the configured timezone
+    const nowStr = now.toLocaleString('en-US', { timeZone: timezone });
+    const localTime = new Date(nowStr);
+    const hours = localTime.getHours();
+    const minutes = localTime.getMinutes();
+    const currentTimeInMinutes = hours * 60 + minutes;
+
+    // Parse start and end times
+    const [startH, startM] = bh.start.split(':').map(Number);
+    const [endH, endM] = bh.end.split(':').map(Number);
+    const startTimeInMinutes = startH * 60 + (startM || 0);
+    const endTimeInMinutes = endH * 60 + (endM || 0);
+
+    if (startTimeInMinutes < endTimeInMinutes) {
+        return currentTimeInMinutes >= startTimeInMinutes && currentTimeInMinutes <= endTimeInMinutes;
+    } else {
+        // Handles overnight hours (e.g., 22:00 - 06:00)
+        return currentTimeInMinutes >= startTimeInMinutes || currentTimeInMinutes <= endTimeInMinutes;
+    }
+}
+
+/**
+ * Checks for auto-escalation rules and applies them.
+ */
+export async function checkEscalation(ticketId: number): Promise<void> {
+    const rules = cache.config.escalation_rules || [];
+    if (rules.length === 0) return;
+
+    const ticket = await db.getTicketById(ticketId, null);
+    if (!ticket) return;
+
+    // Use first_response_at or fallback to analytics event for creation time
+    let createdAt: Date | null = ticket.first_response_at;
+    if (!createdAt) {
+      const createdEvents = await db.getAnalyticsEvents('ticket_created');
+      const ticketCreated = createdEvents.find((e: any) => e.ticketId === ticketId);
+      if (ticketCreated) {
+        createdAt = new Date(ticketCreated.timestamp);
+      }
+    }
+    if (!createdAt) return;
+
+    for (const rule of rules) {
+        const hoursSinceCreated = (Date.now() - createdAt.getTime()) / (1000 * 60 * 60);
+        if (hoursSinceCreated >= rule.after_hours && !ticket.assigned_to) {
+            switch (rule.action) {
+                case 'notify_supervisor':
+                    // Find supervisors and notify them
+                    for (const [id, member] of cache.staffMembers) {
+                        if (member.role === 'supervisor') {
+                            await middleware.sendMessage(
+                                id,
+                                cache.config.staffchat_type,
+                                `${cache.config.language.escalationNotify} ${rule.after_hours}h — Ticket #T${ticketId.toString().padStart(6, '0')}`,
+                                { parse_mode: cache.config.parse_mode },
+                            );
+                        }
+                    }
+                    await db.recordAnalyticsEvent('ticket_escalated', ticketId, null, { reason: `no_response_${rule.after_hours}h` });
+                    break;
+
+                case 'tag_urgent':
+                    await db.setPriority(ticketId, 'urgent' as any);
+                    await db.addTags(ticketId, ['auto-escalated']);
+                    await db.recordAnalyticsEvent('ticket_escalated', ticketId, null, { reason: `auto_tag_${rule.after_hours}h` });
+                    break;
+            }
+        }
+    }
+}
+
+/**
+ * Checks for auto-close on inactivity and closes eligible tickets.
+ */
+export async function checkAutoClose(): Promise<void> {
+    const days = cache.config.auto_close_after_days || 0;
+    if (days <= 0) return;
+
+    try {
+        const cutoffDate = new Date(Date.now() - days * 86400000);
+        const openTickets = await db.Supportee.find({ status: 'open' });
+
+        for (const ticket of openTickets) {
+            // Check if there's been recent activity
+            const messages = await db.TicketMessage.find({ ticketId: ticket.ticketId })
+                .sort({ timestamp: -1 })
+                .limit(1);
+
+            if (messages.length === 0 || new Date(messages[0].timestamp) < cutoffDate) {
+                await db.add(ticket.userid, 'closed', ticket.category, ticket.messenger);
+                await db.setClosedAt(ticket.ticketId);
+                await db.recordAnalyticsEvent('ticket_closed', ticket.ticketId, null, { reason: 'auto_close_inactivity' });
+
+                // Notify user
+                const msg = `${cache.config.language.ticket} #T${ticket.ticketId.toString().padStart(6, '0')} ${cache.config.language.closed}\n\nYour ticket was auto-closed due to inactivity (${days} days). You can open a new ticket at any time.`;
+                await middleware.sendMessage(ticket.userid, ticket.messenger, msg);
+
+                log.info(`Auto-closed ticket #T${ticket.ticketId} (inactivity ${days}d)`);
+            }
+        }
+    } catch (err) {
+        log.error('Error in auto-close check:', err);
+    }
+}
+
+/**
+ * Gets a canned response by key.
+ */
+export function getCannedResponse(key: string): string | null {
+    const responses = cache.config.canned_responses || [];
+    const found = responses.find((r) => r.key.toLowerCase() === key.toLowerCase());
+    return found ? found.text : null;
+}
+
+/**
+ * Lists all available canned response keys.
+ */
+export function listCannedResponses(): string {
+    const responses = cache.config.canned_responses || [];
+    if (responses.length === 0) return 'No canned responses configured.';
+
+    let output = '*Available templates:*\n\n';
+    for (const resp of responses) {
+        output += `/${resp.key} — ${resp.text.substring(0, 50)}${resp.text.length > 50 ? '...' : ''}\n`;
+    }
+    return output;
+}
+
+/**
+ * Handles canned response command. Staff types /template_key to insert the template text.
+ */
+export async function handleCannedResponse(ctx: Context, key: string): Promise<string | null> {
+    const text = getCannedResponse(key);
+    if (!text) return null;
+    return text;
+}
+
+/**
+ * Runs periodic workflow checks (auto-close, escalation).
+ * Should be called from a setInterval in the main index.ts.
+ */
+export async function runWorkflowChecks(): Promise<void> {
+    await checkAutoClose();
+    log.info('Workflow checks completed.');
+}

--- a/src/workflows.ts
+++ b/src/workflows.ts
@@ -2,7 +2,7 @@ import cache from './cache';
 import * as db from './db';
 import * as middleware from './middleware';
 import { Context } from './interfaces';
-import * as log from 'fancy-log'
+import * as log from './logger'
 
 /**
  * Checks if the current time is within business hours.

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -1,4 +1,5 @@
 import cache from '../src/cache';
+import { mergeLanguage } from '../src/language';
 import * as fs from 'fs';
 import * as YAML from 'yaml';
 
@@ -68,5 +69,25 @@ describe('Cache Module', () => {
     expect(cache.config).toHaveProperty('categories');
     expect(cache.config).toHaveProperty('anonymous_replies');
     expect(cache.config).toHaveProperty('clean_replies');
+  });
+});
+
+describe('mergeLanguage', () => {
+  it('applies all default language strings when the config has no language block', () => {
+    const language = mergeLanguage(undefined);
+    expect(language.confirmationMessage).toBeTruthy();
+    expect(language.back).toBeTruthy();
+    expect(language.dear).toBeDefined();
+  });
+
+  it('keeps user overrides while filling missing language keys', () => {
+    const language = mergeLanguage({ ticket: 'Anfrage' });
+    expect(language.ticket).toBe('Anfrage');
+    expect(language.confirmationMessage).toBeTruthy();
+  });
+
+  it('falls back to the legacy contactMessage for confirmationMessage', () => {
+    const language = mergeLanguage({ contactMessage: 'Danke für Ihre Nachricht' });
+    expect(language.confirmationMessage).toBe('Danke für Ihre Nachricht');
   });
 });

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -1,7 +1,7 @@
 // Mock dependencies with better structure
-const mockReply = jest.fn();
-const mockSendMessage = jest.fn();
-const mockCloseAll = jest.fn();
+const mockReply = jest.fn().mockResolvedValue(undefined);
+const mockSendMessage = jest.fn().mockResolvedValue(undefined);
+const mockCloseAll = jest.fn().mockResolvedValue(undefined);
 
 jest.mock('../src/middleware', () => ({
   reply: mockReply,
@@ -11,12 +11,13 @@ jest.mock('../src/middleware', () => ({
 // Mock the entire db module with all needed functions
 jest.mock('../src/db', () => ({
   closeAll: mockCloseAll,
-  open: jest.fn((callback) => callback([])), // Mock the open function
-  getByTicketId: jest.fn((ticketId, callback) => {
-    callback({ userid: 'user123', id: { toString: () => ticketId } });
-  }),
-  reopen: jest.fn(), // Add reopen mock
-  add: jest.fn(),    // Add add mock
+  open: jest.fn().mockResolvedValue([]), // Mock the open function (async)
+  getByTicketId: jest.fn().mockResolvedValue({ userid: 'user123', id: { toString: () => 'ticket1' } }),
+  getTicketById: jest.fn().mockResolvedValue({ userid: 'user123', id: { toString: () => 'ticket1' }, category: null }),
+  reopen: jest.fn().mockResolvedValue(undefined), // Add reopen mock (async)
+  add: jest.fn().mockResolvedValue(undefined),    // Add add mock (async)
+  addTicketMessage: jest.fn().mockResolvedValue(undefined),
+  recordAnalyticsEvent: jest.fn().mockResolvedValue(undefined),
 }));
 
 jest.mock('../src/cache', () => ({
@@ -25,12 +26,18 @@ jest.mock('../src/cache', () => ({
       helpCommandText: 'Help: /start, /help',
       helpCommandStaffText: 'Staff: /clear, /open, /close',
       from: 'From:',
+      openTickets: 'Open Tickets',
+      ticket: 'Ticket',
+      closed: 'closed',
+      ticketClosed: 'Your ticket has been closed.',
+      banned: 'banned',
+      usr_with_ticket: 'User with ticket',
     },
     parse_mode: 'MarkdownV2',
   },
-  ticketIDs: [],
-  ticketStatus: [],
-  ticketSent: [],
+  ticketIDs: {},
+  ticketStatus: {},
+  ticketSent: {},
 }));
 
 import * as commands from '../src/commands';
@@ -40,10 +47,10 @@ import cache from '../src/cache';
 describe('Commands Module', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    // Reset cache arrays
-    cache.ticketIDs.length = 0;
-    cache.ticketStatus.length = 0;
-    cache.ticketSent.length = 0;
+    // Reset cache objects
+    Object.keys(cache.ticketIDs).forEach(k => delete cache.ticketIDs[k]);
+    Object.keys(cache.ticketStatus).forEach(k => delete cache.ticketStatus[k]);
+    Object.keys(cache.ticketSent).forEach(k => delete cache.ticketSent[k]);
   });
 
   const createMockContext = (isAdmin: boolean = false): Context => ({
@@ -122,12 +129,12 @@ describe('Commands Module', () => {
 
     it('should show staff help text for admin users', () => {
       const ctx = createMockContext(true);
-      
+
       commands.helpCommand(ctx);
 
       expect(mockReply).toHaveBeenCalledWith(
         ctx,
-        'Staff: /clear, /open, /close',
+        expect.stringContaining('/clear'),
         { parse_mode: 'MarkdownV2' }
       );
     });
@@ -140,7 +147,7 @@ describe('Commands Module', () => {
       await commands.clearCommand(ctx);
 
       expect(mockCloseAll).toHaveBeenCalled();
-      expect(cache.ticketIDs).toHaveLength(0);
+      expect(Object.keys(cache.ticketIDs)).toHaveLength(0);
       expect(mockReply).toHaveBeenCalledWith(ctx, 'All tickets closed.');
     });
 
@@ -155,66 +162,64 @@ describe('Commands Module', () => {
   });
 
   describe('openCommand', () => {
-    it('should process open tickets for admin users', () => {
+    it('should process open tickets for admin users', async () => {
       const ctx = createMockContext(true);
-      
-      commands.openCommand(ctx);
+
+      await commands.openCommand(ctx);
 
       // The function should call db.open and then reply
-      // Since we mocked db.open to call callback with empty array
       expect(mockReply).toHaveBeenCalled();
     });
 
-    it('should reject non-admin users', () => {
+    it('should reject non-admin users', async () => {
       const ctx = createMockContext(false);
-      
-      commands.openCommand(ctx);
+
+      await commands.openCommand(ctx);
 
       // Function should return early for non-admin users
-      // Check that no reply was sent (depends on implementation)
     });
   });
 
   describe('closeCommand', () => {
-    it('should handle ticket closing for admin users', () => {
+    it('should handle ticket closing for admin users', async () => {
       const ctx = createMockContext(true);
-      commands.closeCommand(ctx);
+      await commands.closeCommand(ctx);
       expect(true).toBe(true); // Test passes if no errors thrown
     });
 
-    it('should not fail when called', () => {
+    it('should not fail when called', async () => {
       const ctx = createMockContext(true);
-      commands.closeCommand(ctx);
+      await commands.closeCommand(ctx);
       expect(true).toBe(true);
     });
   });
 
   describe('reopenCommand', () => {
-    it('should handle ticket reopening for admin users', () => {
+    it('should handle ticket reopening for admin users', async () => {
       const ctx = createMockContext(true);
-      commands.reopenCommand(ctx);
+      await commands.reopenCommand(ctx);
       expect(true).toBe(true);
     });
   });
 
   describe('banCommand', () => {
-    it('should handle user banning for admin users', () => {
+    it('should handle user banning for admin users', async () => {
       const ctx = createMockContext(true);
-      commands.banCommand(ctx);
+      await commands.banCommand(ctx);
       expect(true).toBe(true);
     });
   });
 
   describe('unbanCommand', () => {
-    it('should handle user unbanning for admin users', () => {
+    it('should handle user unbanning for admin users', async () => {
       const ctx = createMockContext(true);
-      commands.unbanCommand(ctx);
+      await commands.unbanCommand(ctx);
       expect(true).toBe(true);
     });
   });
 
   describe('Error handling', () => {
-    it('should handle missing reply message gracefully', () => {
+    it('should handle missing reply message gracefully', async () => {
       const ctx = createMockContext(true);
       ctx.message.reply_to_message = {
         from: { is_bot: false },
@@ -222,8 +227,8 @@ describe('Commands Module', () => {
         caption: '',
       };
 
-      expect(() => commands.closeCommand(ctx)).not.toThrow();
-      expect(() => commands.reopenCommand(ctx)).not.toThrow();
+      await expect(commands.closeCommand(ctx)).resolves.not.toThrow();
+      await expect(commands.reopenCommand(ctx)).resolves.not.toThrow();
     });
   });
 });

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -134,20 +134,20 @@ describe('Commands Module', () => {
   });
 
   describe('clearCommand', () => {
-    it('should clear all tickets for admin users', () => {
+    it('should clear all tickets for admin users', async () => {
       const ctx = createMockContext(true);
-      
-      commands.clearCommand(ctx);
+
+      await commands.clearCommand(ctx);
 
       expect(mockCloseAll).toHaveBeenCalled();
       expect(cache.ticketIDs).toHaveLength(0);
       expect(mockReply).toHaveBeenCalledWith(ctx, 'All tickets closed.');
     });
 
-    it('should reject non-admin users', () => {
+    it('should reject non-admin users', async () => {
       const ctx = createMockContext(false);
-      
-      commands.clearCommand(ctx);
+
+      await commands.clearCommand(ctx);
 
       expect(mockCloseAll).not.toHaveBeenCalled();
       expect(mockReply).not.toHaveBeenCalled();

--- a/test/mocks.ts
+++ b/test/mocks.ts
@@ -24,6 +24,7 @@ jest.mock('../src/cache', () => ({
             msg_sent: 'Message sent',
         },
         dev_mode: false,
+        log_level: 'NONE',
         clean_replies: false,
         anonymous_replies: false,
         staffchat_type: 'telegram',

--- a/test/mocks.ts
+++ b/test/mocks.ts
@@ -42,20 +42,38 @@ jest.mock('../src/cache', () => ({
     ticketSent: [],
     io: { to: jest.fn().mockReturnValue({ emit: jest.fn() }) },
     userId: 123,
+    staffMembers: new Map(),
+    mutedTickets: new Set(),
+    recoveryBaseline: 0,
 }));
 
 jest.mock('../src/db', () => ({
     closeAll: jest.fn().mockResolvedValue(undefined),
     open: jest.fn((callback, groups) => callback([])),
     add: jest.fn().mockResolvedValue(0),
-    getTicketById: jest.fn((id, group, callback) =>
-        callback({ id: 1, userid: 456, category: 'test' })
-    ),
-    getTicketByInternalId: jest.fn(),
+    getTicketById: jest.fn().mockResolvedValue({ id: 1, userid: 456, category: 'test' }),
+    getTicketByInternalId: jest.fn().mockResolvedValue(null),
     getByTicketId: jest.fn((ticketId, callback) =>
         callback({ userid: 789, id: { toString: () => ticketId } })
     ),
     reopen: jest.fn(),
+    // New team collaboration & analytics methods
+    addTicketMessage: jest.fn().mockResolvedValue(undefined),
+    getConversationHistory: jest.fn().mockResolvedValue([]),
+    recordAnalyticsEvent: jest.fn().mockResolvedValue(undefined),
+    getAnalyticsEvents: jest.fn().mockResolvedValue([]),
+    addInternalNote: jest.fn().mockResolvedValue(undefined),
+    getInternalNotes: jest.fn().mockResolvedValue([]),
+    assignTicket: jest.fn().mockResolvedValue(undefined),
+    unassignTicket: jest.fn().mockResolvedValue(undefined),
+    addTags: jest.fn().mockResolvedValue(undefined),
+    removeTag: jest.fn().mockResolvedValue(undefined),
+    setPriority: jest.fn().mockResolvedValue(undefined),
+    setTriageInfo: jest.fn().mockResolvedValue(undefined),
+    setFirstResponseAt: jest.fn().mockResolvedValue(undefined),
+    setClosedAt: jest.fn().mockResolvedValue(undefined),
+    openByTag: jest.fn((callback, tag, category) => callback([])),
+    recordCSAT: jest.fn().mockResolvedValue(undefined),
 }));
 
 // --- Mocks for External Modules --- //
@@ -72,6 +90,7 @@ jest.mock('grammy', () => ({
             sendPhoto: jest.fn(),
             sendDocument: jest.fn(),
             sendVideo: jest.fn(),
+            getMessages: jest.fn().mockResolvedValue([]),
             config: { use: jest.fn() },
         },
         botInfo: { username: 'dummy_bot' },
@@ -94,3 +113,11 @@ jest.mock('ws', () => {
         on: jest.fn(),
     }));
 });
+
+jest.mock('../src/recovery', () => ({
+    runRecovery: jest.fn().mockResolvedValue(undefined),
+}));
+
+// NOTE: ../src/staff is NOT globally mocked here. Tests that need it can either:
+// - Import the real implementation (e.g., staff.test.ts tests privateReply, ticketMsg)
+// - Mock specific functions inline with jest.mock in their own test file

--- a/test/mocks.ts
+++ b/test/mocks.ts
@@ -45,9 +45,9 @@ jest.mock('../src/cache', () => ({
 }));
 
 jest.mock('../src/db', () => ({
-    closeAll: jest.fn(),
+    closeAll: jest.fn().mockResolvedValue(undefined),
     open: jest.fn((callback, groups) => callback([])),
-    add: jest.fn(),
+    add: jest.fn().mockResolvedValue(0),
     getTicketById: jest.fn((id, group, callback) =>
         callback({ id: 1, userid: 456, category: 'test' })
     ),

--- a/test/staff.test.ts
+++ b/test/staff.test.ts
@@ -22,10 +22,15 @@ import * as db from '../src/db';
 // Mock dependencies
 jest.mock('../src/cache');
 jest.mock('../src/middleware');
-jest.mock('../src/db');
+jest.mock('../src/db', () => ({
+    addTicketMessage: jest.fn().mockResolvedValue(undefined),
+    recordAnalyticsEvent: jest.fn().mockResolvedValue(undefined),
+    setFirstResponseAt: jest.fn().mockResolvedValue(undefined),
+    setClosedAt: jest.fn().mockResolvedValue(undefined),
+}));
 jest.mock('fancy-log');
 
-const mockSendMessage = jest.fn();
+const mockSendMessage = jest.fn().mockResolvedValue(undefined);
 const mockStrictEscape = jest.fn((text) => text);
 const mockReply = jest.fn();
 

--- a/test/text-handler.test.ts
+++ b/test/text-handler.test.ts
@@ -17,6 +17,8 @@ jest.mock('../src/db', () => ({
   add: mockAdd,
   checkBan: mockCheckBan,
   getTicketByUserId: mockGetTicketByUserId,
+  addTicketMessage: jest.fn().mockResolvedValue(undefined),
+  recordAnalyticsEvent: jest.fn().mockResolvedValue(undefined),
 }));
 
 jest.mock('../src/users', () => ({

--- a/test/text.test.ts
+++ b/test/text.test.ts
@@ -17,6 +17,8 @@ jest.mock('../src/db', () => ({
   add: mockAdd,
   checkBan: mockCheckBan,
   getTicketByUserId: mockGetTicketByUserId,
+  addTicketMessage: jest.fn().mockResolvedValue(undefined),
+  recordAnalyticsEvent: jest.fn().mockResolvedValue(undefined),
 }));
 
 jest.mock('../src/users', () => ({

--- a/test/users.test.ts
+++ b/test/users.test.ts
@@ -9,44 +9,68 @@ jest.mock('../src/middleware', () => ({
   sendMessage: mockSendMessage,
   reply: mockReply,
   strictEscape: jest.fn((str) => str),
+  buildInlineKeyboard: jest.fn().mockReturnValue([]),
 }));
 
 jest.mock('../src/db', () => ({
   add: mockAdd,
   getTicketByUserId: mockGetTicketByUserId,
   addIdAndName: mockAddIdAndName,
+  addTicketMessage: jest.fn().mockResolvedValue(undefined),
+  recordAnalyticsEvent: jest.fn().mockResolvedValue(undefined),
 }));
 
 jest.mock('../src/cache', () => ({
-  config: {
-    language: {
-      confirmationMessage: 'Thank you for contacting us.',
-      ticket: 'Ticket',
-      automatedReplySent: 'Automated reply sent',
-      blockedSpam: 'You are sending too many messages',
+  __esModule: true,
+  default: {
+    config: {
+      language: {
+        confirmationMessage: 'Thank you for contacting us.',
+        ticket: 'Ticket',
+        automatedReplySent: 'Automated reply sent',
+        blockedSpam: 'You are sending too many messages',
+      },
+      autoreply: [
+        { question: 'hello', answer: 'Hi there!' },
+      ],
+      use_llm: false,
+      autoreply_confirmation: true,
+      show_auto_replied: true,
+      show_user_ticket: true,
+      spam_cant_msg: 3,
+      spam_time: 5000,
+      staffchat_id: 'staff123',
+      staffchat_type: 'telegram',
+      allow_private: false,
+      parse_mode: 'MarkdownV2',
     },
-    autoreply: [
-      { question: 'hello', answer: 'Hi there!' },
-    ],
-    use_llm: false,
-    autoreply_confirmation: true,
-    show_auto_replied: true,
-    show_user_ticket: true,
-    spam_cant_msg: 3,
-    spam_time: 5000,
-    staffchat_id: 'staff123',
-    staffchat_type: 'telegram',
-    allow_private: false,
-    parse_mode: 'MarkdownV2',
+    userId: '',
+    ticketIDs: [],
+    ticketStatus: {},
+    ticketSent: {},
   },
-  userId: '',
-  ticketIDs: [],
-  ticketStatus: {},
-  ticketSent: [],
 }));
 
 jest.mock('../src/addons/llm', () => ({
   getResponseFromLLM: jest.fn(),
+}));
+
+jest.mock('../src/triage', () => ({
+  analyzeMessage: jest.fn().mockResolvedValue(null),
+  formatTriagePrefix: jest.fn().mockReturnValue(''),
+}));
+
+jest.mock('../src/webhooks', () => ({
+  webhooks: {
+    ticketCreated: jest.fn().mockResolvedValue(undefined),
+    ticketReplied: jest.fn().mockResolvedValue(undefined),
+    ticketClosed: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
+jest.mock('../src/workflows', () => ({
+  isWithinBusinessHours: jest.fn().mockReturnValue(true),
+  runWorkflowChecks: jest.fn().mockResolvedValue(undefined),
 }));
 
 jest.mock('fancy-log', () => ({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "sourceMap": true,
     "moduleResolution": "node16",
     "esModuleInterop": true,
-    "strictNullChecks" : false,
+    "strict": true,
     "skipLibCheck": true,
     "isolatedModules": true,
   },


### PR DESCRIPTION
## Summary

Batch of changes accumulated on `master` since the last release: platform/runtime fixes, new collaboration & analytics features, and a configurable file logger.

### Fixes
- **Docker build**: `prod` now runs the compiled `build/index.js` instead of re-compiling with `tsc`/`ts-node` in the production stage; multi-stage `Dockerfile` copies the build output. MongoDB, mongo-express and signal-cli ports bind to `127.0.0.1` only.
- **Language defaults**: the default language strings are always merged, so configs without a full `language:` block no longer produce `undefined` in the confirmation message or crash on missing keys. The legacy `contactMessage` key is honoured as `confirmationMessage`.
- **LLM auto-reply**: log when the model returns no answer and warn at startup when `use_llm` is enabled with an empty `llm_knowledge` (the model is instructed to only answer from the knowledge base).
- Error handler rewritten with proper rate limiting; assorted code-smell cleanups.

### Features
- Team collaboration: ticket assignment, priorities, tags, internal notes, staff roles/permissions, ticket resolution flow.
- Analytics events, daily summary, workflow periodic checks, escalation rules, business hours.
- LLM conversation memory, staff assist drafts, translation, AI triage.
- Discord and Slack platform addons.
- File logger with `log_level: NONE|ERROR|INFO` writing `config/debug.log`.
- Upgrade to Node 24 / grammy 1.43; tests extended (71 passing).

### Notes
- `docker-publish.yml` is tag-triggered, so merging does not publish a new image.
- `config/config-sample.yaml` gained `log_level`.

Closes #184
Closes #178
Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)
