### PR TITLE
fix: respect MONGO_URI environment variable

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -81,6 +81,12 @@ cache.config = {
   ...parsedConfig,
 } as unknown as Config;
 
+// Environment variables should override config.yaml/defaults.
+// This is especially important for authenticated MongoDB deployments.
+if (process.env.MONGO_URI) {
+  cache.config.mongodb_uri = process.env.MONGO_URI;
+}
+
 // Ensure array fields are actually arrays (YAML `{}` becomes empty object)
 const arrayFields = [
   'categories', 'staff_roles', 'webhooks', 'autoreply',


### PR DESCRIPTION
## Summary

Fix MongoDB URI precedence so `MONGO_URI` overrides `config.yaml` and the default Docker URI.

The current default makes the env fallback unreachable, causing external authenticated MongoDB instances like Railway/Atlas to connect without credentials.

## Fix

Use this precedence:

`MONGO_URI env > config.yaml > default`

This fixes both normal DB connections and migrations without duplicating URI logic.
