### PR TITLE
Make the new commands and options work on every addon

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,11 @@ User commands:
 
 All texts are configurable in the `language:` section of `config.yaml`. See the [wiki](https://github.com/bostrot/telegram-support-bot/wiki/Commands) for details.
 
+Commands, canned responses and `user_commands` work on every enabled platform (Telegram, Signal,
+Slack, Discord). A few options depend on features only Telegram has and are ignored elsewhere:
+`staffchat_thread_id` (forum topics), `start_keyboard` (reply keyboards), `forward_stickers`
+(stickers) and `forward_edited_messages` (edit events).
+
 ## 📦 Install
 
 See the [wiki](https://github.com/bostrot/telegram-support-bot/wiki/Getting-started) for detailed instructions.

--- a/src/addons/discord/index.ts
+++ b/src/addons/discord/index.ts
@@ -371,7 +371,8 @@ class DiscordAddon implements Addon {
         callback(ctx);
         return;
       } else if (trigger instanceof RegExp && trigger.test(text)) {
-        ctx.match = trigger.exec(text)?.toString() || '';
+        // Hand over the match array like grammY does, so capture groups survive
+        ctx.match = trigger.exec(text) ?? undefined;
         callback(ctx);
         return;
       }

--- a/src/addons/signal/index.ts
+++ b/src/addons/signal/index.ts
@@ -303,11 +303,13 @@ class SignalAddon implements Addon {
       let isCommand = false;
       if (messageContext.message && typeof messageContext.message.text === 'string' &&
           messageContext.message.text.startsWith('/')) {
-        isCommand = true;
-        const parts = messageContext.message.text.split(' ');
+        const parts = messageContext.message.text.trim().split(' ');
         const commandName = parts[0].substring(1);
         const commandKey = `command:${commandName}`;
         if (this.eventHandlers[commandKey]) {
+          isCommand = true;
+          // Everything behind the command is its argument, like grammY's ctx.match
+          messageContext.match = parts.slice(1).join(' ');
           this.eventHandlers[commandKey].forEach(handler => handler(messageContext));
         }
       }
@@ -317,15 +319,23 @@ class SignalAddon implements Addon {
         this.eventHandlers['message'].forEach(handler => handler(messageContext));
       }
       
-      // Process hears handlers if message is not a command.
-      if (!isCommand) {
-        this.hearsHandlers.forEach(({ trigger, callback }) => {
-          if (typeof trigger === 'string' && messageContext.message.text === trigger) {
+      // Process hears handlers unless a registered command already handled the message.
+      // Unknown slash commands fall through here so custom user commands (#84) and
+      // canned responses reach Signal users too. Only the first matching trigger runs,
+      // like grammY does — otherwise the catch-all /(.+)/ would open a ticket on top of
+      // every canned answer.
+      const messageText = messageContext.message?.text;
+      if (!isCommand && typeof messageText === 'string') {
+        for (const { trigger, callback } of this.hearsHandlers) {
+          if (typeof trigger === 'string' && messageText === trigger) {
             callback(messageContext);
-          } else if (trigger instanceof RegExp && trigger.test(messageContext.message.text)) {
+            break;
+          } else if (trigger instanceof RegExp && trigger.test(messageText)) {
+            messageContext.match = trigger.exec(messageText) ?? undefined;
             callback(messageContext);
+            break;
           }
-        });
+        }
       }
       
     } catch (err) {

--- a/src/addons/slack/index.ts
+++ b/src/addons/slack/index.ts
@@ -302,7 +302,8 @@ class SlackAddon implements Addon {
         callback(ctx);
         return;
       } else if (trigger instanceof RegExp && trigger.test(text)) {
-        ctx.match = trigger.exec(text)?.toString() || '';
+        // Hand over the match array like grammY does, so capture groups survive
+        ctx.match = trigger.exec(text) ?? undefined;
         callback(ctx);
         return;
       }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -9,6 +9,7 @@ import * as analytics from './analytics';
 import * as workflows from './workflows';
 import { extractSupporteeId } from './staff';
 import * as webhooks from './webhooks';
+import { matchArg } from './match';
 
 const escapeRegex = (str: string): string => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
@@ -345,7 +346,7 @@ const unbanCommand = async (ctx: Context): Promise<void> => {
  */
 const assignCommand = async (ctx: Context): Promise<void> => {
   if (!ctx.session.admin) return;
-  const args = ctx.match?.trim();
+  const args = matchArg(ctx.match);
   if (!args) {
     middleware.reply(ctx, 'Usage: /assign <staff_telegram_id>');
     return;
@@ -398,7 +399,7 @@ const unassignCommand = async (ctx: Context): Promise<void> => {
  */
 const tagCommand = async (ctx: Context): Promise<void> => {
   if (!ctx.session.admin) return;
-  const args = ctx.match?.trim();
+  const args = matchArg(ctx.match);
   if (!args) {
     middleware.reply(ctx, 'Usage: /tag <tag1,tag2,...>');
     return;
@@ -425,7 +426,7 @@ const tagCommand = async (ctx: Context): Promise<void> => {
  */
 const untagCommand = async (ctx: Context): Promise<void> => {
   if (!ctx.session.admin) return;
-  const args = ctx.match?.trim();
+  const args = matchArg(ctx.match);
   if (!args) {
     middleware.reply(ctx, 'Usage: /untag <tag>');
     return;
@@ -451,7 +452,7 @@ const untagCommand = async (ctx: Context): Promise<void> => {
  */
 const priorityCommand = async (ctx: Context): Promise<void> => {
   if (!ctx.session.admin) return;
-  const args = ctx.match?.trim().toLowerCase() ?? '';
+  const args = matchArg(ctx.match).toLowerCase();
   const validPriorities = ['low', 'normal', 'high', 'urgent'];
   if (!args || !validPriorities.includes(args)) {
     middleware.reply(ctx, `Usage: /priority <${validPriorities.join('|')}>`);
@@ -520,7 +521,7 @@ const unmuteCommand = async (ctx: Context): Promise<void> => {
  */
 const noteCommand = async (ctx: Context): Promise<void> => {
   if (!ctx.session.admin) return;
-  const args = ctx.match?.trim();
+  const args = matchArg(ctx.match);
   if (!args) {
     middleware.reply(ctx, 'Usage: /note <internal note text>');
     return;
@@ -607,7 +608,7 @@ const ticketCommand = async (ctx: Context): Promise<void> => {
   const esc = middleware.strictEscape;
 
   let ticket: ISupportee | null = null;
-  const requestedId = parseTicketArg(ctx.match);
+  const requestedId = parseTicketArg(matchArg(ctx.match));
   if (requestedId) {
     ticket = await db.getByTicketId(String(requestedId));
   } else {
@@ -665,7 +666,7 @@ const broadcastCommand = async (ctx: Context): Promise<void> => {
     middleware.reply(ctx, 'Broadcast is disabled. Set allow_broadcast: true in config.yaml to enable it.');
     return;
   }
-  const text = ctx.match?.trim();
+  const text = matchArg(ctx.match);
   if (!text) {
     middleware.reply(ctx, 'Usage: /broadcast <text>');
     return;

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -8,20 +8,10 @@ import { Addon, Context } from './interfaces';
 import * as analytics from './analytics';
 import * as workflows from './workflows';
 import * as edited from './edited';
+import { matchedCommand } from './match';
 import * as log from './logger'
 
-/**
- * grammY sets ctx.match to a string for string triggers and to a RegExpMatchArray for
- * RegExp triggers; normalise to the first capture group (or the whole match).
- */
-export function matchedCommand(match: unknown): string | null {
-  if (typeof match === 'string') return match.replace(/^\//, '') || null;
-  if (Array.isArray(match)) {
-    const value = (match[1] ?? match[0]) as string | undefined;
-    return value ? value.replace(/^\//, '') : null;
-  }
-  return null;
-}
+export { matchedCommand };
 
 /**
  * Reply-keyboard markup for the /start message (start_keyboard, #142).
@@ -196,9 +186,12 @@ export function registerCommonHandlers(addon: Addon, keys?: string[][]) {
         const replyText = replyMsg.text || replyMsg.caption;
         const match = replyText.match(/#T(.*)/);
         if (match) {
-          // Store canned text on context for staff handler to pick up
+          // Put the canned text on the context and run the regular chat handler with it —
+          // a `hears` handler ends the middleware chain, so it would never be reached
+          // on its own and the template would be dropped silently.
           ctx.message.text = cannedText;
-          return; // Let the regular chat handler process it
+          await text.handleText(addon, ctx, keys || []);
+          return;
         }
       }
       middleware.reply(ctx, `Template "${cmd}":\n\n${cannedText}`, { parse_mode: cache.config.parse_mode });

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -349,7 +349,11 @@ export interface Cache {
 export class Context {
   messenger: Messenger = 'telegram' as Messenger;
   update_id: number = 0;
-  match?: string;
+  /**
+   * Command argument (string) or RegExp match (array), depending on the trigger —
+   * see `matchArg`/`matchedCommand` in `src/match.ts` for reading it safely.
+   */
+  match?: string | RegExpMatchArray;
   message: {
     web_msg: boolean;
     message_id: number;
@@ -477,6 +481,8 @@ export interface Addon {
 export enum Messenger {
   TELEGRAM = 'telegram',
   SIGNAL = 'signal',
+  SLACK = 'slack',
+  DISCORD = 'discord',
   WEB = 'web',
 }
 

--- a/src/match.ts
+++ b/src/match.ts
@@ -1,0 +1,31 @@
+/**
+ * Helpers around `ctx.match`.
+ *
+ * grammY sets `ctx.match` to a string for command triggers (the text behind the
+ * command) and to a `RegExpMatchArray` for RegExp triggers. The Signal, Slack and
+ * Discord addons follow the same contract, so every consumer has to cope with both
+ * shapes — these two helpers do that in one place.
+ */
+export type Match = string | RegExpMatchArray | undefined | null;
+
+/**
+ * The argument behind a command: `/ticket 42` → `42`.
+ *
+ * For RegExp triggers the first capture group is used, falling back to the whole
+ * match. Returns an empty string when there is no argument.
+ */
+export function matchArg(match: Match): string {
+  if (typeof match === 'string') return match.trim();
+  if (Array.isArray(match)) return String(match[1] ?? match[0] ?? '').trim();
+  return '';
+}
+
+/**
+ * The command key of a `/key` style trigger, without the leading slash.
+ *
+ * @returns the key, or null when the match holds no usable value.
+ */
+export function matchedCommand(match: Match): string | null {
+  const value = matchArg(match);
+  return value.replace(/^\//, '') || null;
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,5 +1,7 @@
 import cache from './cache';
 import SignalAddon from './addons/signal';
+import SlackAddon from './addons/slack';
+import DiscordAddon from './addons/discord';
 import { Context, Messenger } from './interfaces';
 import TelegramAddon from './addons/telegram';
 
@@ -81,6 +83,10 @@ async function sendMessage (
       return await TelegramAddon.getInstance().sendMessage(id, cleanedMsg, extra);
     case Messenger.SIGNAL:
       return await SignalAddon.getInstance().sendMessage(id, cleanedMsg, extra);
+    case Messenger.SLACK:
+      return await SlackAddon.getInstance().sendMessage(id, cleanedMsg, extra);
+    case Messenger.DISCORD:
+      return await DiscordAddon.getInstance().sendMessage(id, cleanedMsg, extra);
     case Messenger.WEB: {
       const socketId = id.toString().split('WEB')[1];
       cache.io.to(socketId).emit('chat_staff', cleanedMsg);

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -14,7 +14,9 @@ function isOutsideStaffThread(ctx: Context, staffchatId: string | number): boole
   const msg = ctx.message?.message_id ? ctx.message : ctx.editedMessage;
   // Callback queries and other non-message updates carry no thread id; leave them alone
   if (!msg) return false;
-  return (msg.message_thread_id ?? null) !== threadId;
+  const messageThreadId = msg.message_thread_id;
+  // Compare as strings: YAML may hand us the id as either a number or a string
+  return messageThreadId == null || String(messageThreadId) !== String(threadId);
 }
 
 /**

--- a/test/addon-parity.test.ts
+++ b/test/addon-parity.test.ts
@@ -1,0 +1,160 @@
+// Feature parity across addons: the handlers registered by registerCommonHandlers must
+// fit every platform — Telegram-only extras (stickers, reply keyboard) stay off elsewhere,
+// while the shared commands (#84, #85, #159, #112) reach all of them.
+const mockReply = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('../src/middleware', () => ({
+  reply: mockReply,
+  sendMessage: jest.fn().mockResolvedValue(undefined),
+  strictEscape: jest.fn((str: string) => str),
+  buildInlineKeyboard: jest.fn().mockReturnValue({}),
+}));
+jest.mock('../src/db', () => ({
+  getTicketByUserId: jest.fn().mockResolvedValue(null),
+  getByTicketId: jest.fn().mockResolvedValue(null),
+  getTicketByInternalId: jest.fn().mockResolvedValue(null),
+  getAllUsers: jest.fn().mockResolvedValue([]),
+  add: jest.fn().mockResolvedValue(0),
+  addTicketMessage: jest.fn().mockResolvedValue(undefined),
+  addIdAndName: jest.fn().mockResolvedValue(undefined),
+  open: jest.fn().mockResolvedValue([]),
+  recordAnalyticsEvent: jest.fn().mockResolvedValue(undefined),
+  setClosedAt: jest.fn().mockResolvedValue(undefined),
+  getInternalNotes: jest.fn().mockResolvedValue([]),
+  getConversationHistory: jest.fn().mockResolvedValue([]),
+}));
+jest.mock('../src/users', () => ({ chat: jest.fn() }));
+jest.mock('../src/team', () => ({
+  getStaffRole: jest.fn().mockReturnValue(null),
+  addInternalNoteCommand: jest.fn(),
+  canPerformAction: jest.fn().mockReturnValue(true),
+}));
+jest.mock('../src/webhooks', () => ({ webhooks: { ticketReplied: jest.fn(), ticketClosed: jest.fn() } }));
+jest.mock('../src/analytics', () => ({ sendCSATSurvey: jest.fn(), handleCSATCallback: jest.fn(), showStatsCommand: jest.fn() }));
+jest.mock('../src/inline', () => ({
+  replyKeyboard: (keys: string[][]) => ({ reply_markup: { keyboard: keys } }),
+  callbackQuery: jest.fn(),
+}));
+jest.mock('../src/cache', () => ({
+  __esModule: true,
+  default: {
+    config: {
+      language: { back: 'Back', startCommandText: 'Welcome!', services: 'Services', prvChatOnly: 'Private only' },
+      parse_mode: 'MarkdownV2',
+      staffchat_id: '-100123',
+      staffchat_type: 'telegram',
+      categories: [],
+      pass_start: false,
+      forward_stickers: true,
+      forward_edited_messages: true,
+      start_keyboard: ['FAQ'],
+      user_commands: [{ command: 'pricing', text: 'Plans start at 5 EUR' }],
+      canned_responses: [],
+    },
+    ticketIDs: {},
+    ticketStatus: {},
+    ticketSent: {},
+  },
+}));
+
+import cache from '../src/cache';
+import { Addon, Context, Messenger } from '../src/interfaces';
+import { registerCommonHandlers } from '../src/handlers';
+
+type Handler = (ctx: Context) => unknown;
+
+interface Captured {
+  commands: Map<string, Handler>;
+  hears: Array<{ trigger: unknown; cb: Handler }>;
+  on: unknown[];
+}
+
+/** Registers the common handlers on a stub addon and records what was asked for. */
+const register = (platform: string, supportsStickers: boolean): Captured => {
+  const captured: Captured = { commands: new Map(), hears: [], on: [] };
+  const addon = {
+    platform,
+    command: (name: string, cb: Handler) => captured.commands.set(name, cb),
+    hears: (trigger: unknown, cb: Handler) => captured.hears.push({ trigger, cb }),
+    on: (filter: unknown) => captured.on.push(filter),
+    catch: jest.fn(),
+    sendMessage: jest.fn(),
+    sendPhoto: jest.fn(),
+    sendDocument: jest.fn(),
+    sendVideo: jest.fn(),
+    ...(supportsStickers ? { sendSticker: jest.fn() } : {}),
+  } as unknown as Addon;
+  registerCommonHandlers(addon);
+  return captured;
+};
+
+const userCommandHandler = (captured: Captured): Handler =>
+  captured.hears.find((h) => h.trigger instanceof RegExp && h.trigger.source.startsWith('^\\/(\\w+)'))!.cb;
+
+const makeCtx = (messenger: Messenger, overrides: Record<string, unknown> = {}): Context =>
+  ({
+    message: {
+      text: '/pricing',
+      message_id: 1,
+      from: { id: '42', first_name: 'Alice', username: 'alice', is_bot: false },
+      chat: { id: '42', type: 'private' },
+      caption: '',
+      reply_to_message: { from: { is_bot: false }, text: '', caption: '' },
+    },
+    messenger,
+    session: { admin: false, modeData: {}, group: '', groupTag: '', groupCategory: null },
+    chat: { id: '42', type: 'private' },
+    from: { id: '42', username: 'alice' },
+    ...overrides,
+  } as unknown as Context);
+
+// The platforms the bot ships with; only Telegram implements stickers today.
+const platforms: Array<[string, Messenger, boolean]> = [
+  ['telegram', Messenger.TELEGRAM, true],
+  ['signal', Messenger.SIGNAL, false],
+  ['slack', Messenger.SLACK, false],
+  ['discord', Messenger.DISCORD, false],
+];
+
+describe.each(platforms)('registerCommonHandlers on %s', (platform, messenger, supportsStickers) => {
+  let captured: Captured;
+
+  beforeAll(() => {
+    captured = register(platform, supportsStickers);
+  });
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('registers the shared commands', () => {
+    for (const command of ['open', 'close', 'ticket', 'broadcast', 'id', 'help']) {
+      expect(captured.commands.has(command)).toBe(true);
+    }
+  });
+
+  it('registers the sticker handler only where the addon can send stickers (#107)', () => {
+    expect(captured.on.some((f) => Array.isArray(f) && f[0] === ':sticker')).toBe(supportsStickers);
+    // photos, documents and videos work everywhere
+    expect(captured.on).toContainEqual([':photo']);
+    expect(captured.on).toContainEqual([':document']);
+  });
+
+  it('answers custom user commands (#84)', async () => {
+    // Telegram/Slack/Discord hand over a RegExp match array, Signal a plain string
+    const match: unknown = platform === 'signal' ? 'pricing' : ['/pricing', 'pricing'];
+    await userCommandHandler(captured)(makeCtx(messenger, { match }));
+    expect(mockReply).toHaveBeenCalledWith(expect.anything(), 'Plans start at 5 EUR', { parse_mode: 'MarkdownV2' });
+  });
+
+  it('only offers the /start reply keyboard on Telegram (#142)', async () => {
+    cache.config.categories = [];
+    await captured.commands.get('start')!(makeCtx(messenger));
+    if (platform === 'telegram') {
+      expect(mockReply).toHaveBeenCalledWith(expect.anything(), 'Welcome!', {
+        parse_mode: 'MarkdownV2',
+        reply_markup: { keyboard: [['FAQ']], resize_keyboard: true },
+      });
+    } else {
+      expect(mockReply).toHaveBeenCalledWith(expect.anything(), 'Welcome!');
+    }
+  });
+});

--- a/test/discord-addon.test.ts
+++ b/test/discord-addon.test.ts
@@ -1,0 +1,83 @@
+// Tests for the Discord addon dispatch: command arguments and RegExp matches handed to
+// handlers the same way grammY does, so the shared commands work on Discord too.
+const axiosInstance = {
+  post: jest.fn().mockResolvedValue({ data: { id: '55' } }),
+  get: jest.fn().mockResolvedValue({ data: [] }),
+};
+
+jest.mock('axios', () => ({ create: jest.fn(() => axiosInstance) }));
+jest.mock('../src/handlers', () => ({ registerCommonHandlers: jest.fn() }));
+jest.mock('../src/cache', () => ({
+  __esModule: true,
+  default: { config: { discord_bot_token: 'token', discord_channel_id: '', discord_enabled: true } },
+}));
+
+import DiscordAddon from '../src/addons/discord';
+import { Context } from '../src/interfaces';
+
+const message = (content: string) => ({
+  id: '1',
+  channel_id: '99',
+  channel_type: 0,
+  content,
+  timestamp: new Date().toISOString(),
+  author: { id: '7', username: 'alice', bot: false },
+});
+
+describe('DiscordAddon dispatch', () => {
+  const addon = DiscordAddon.getInstance();
+  const commandHandlers = (addon as unknown as { commandHandlers: Map<string, unknown> }).commandHandlers;
+  const hears = (addon as unknown as { hearsHandlers: unknown[] }).hearsHandlers;
+  const deliver = (content: string) =>
+    (addon as unknown as { handleMessageCreate: (msg: unknown) => void }).handleMessageCreate(message(content));
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    commandHandlers.clear();
+    hears.length = 0;
+  });
+
+  it('passes the text behind a command as ctx.match', () => {
+    const ticket = jest.fn();
+    addon.command('ticket', ticket);
+    deliver('/ticket 1234');
+
+    expect((ticket.mock.calls[0][0] as Context).match).toBe('1234');
+  });
+
+  it('hands RegExp triggers the match array instead of a stringified one (#84)', () => {
+    const canned = jest.fn();
+    addon.hears(/^\/(\w+)(?:@\w+)?$/, canned);
+    deliver('/faq');
+
+    const match = (canned.mock.calls[0][0] as Context).match;
+    expect(Array.isArray(match)).toBe(true);
+    expect((match as RegExpMatchArray)[1]).toBe('faq');
+  });
+
+  it('prefers a registered command over the hears fall-through', () => {
+    const close = jest.fn();
+    const canned = jest.fn();
+    addon.command('close', close);
+    addon.hears(/^\/(\w+)$/, canned);
+    deliver('/close');
+
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(canned).not.toHaveBeenCalled();
+  });
+
+  it('ignores messages sent by bots', () => {
+    const canned = jest.fn();
+    addon.hears(/^\/(\w+)$/, canned);
+    (addon as unknown as { handleMessageCreate: (msg: unknown) => void }).handleMessageCreate({
+      ...message('/faq'),
+      author: { id: '7', username: 'bot', bot: true },
+    });
+
+    expect(canned).not.toHaveBeenCalled();
+  });
+
+  it('has no sticker support, so the sticker handler is never registered', () => {
+    expect((addon as { sendSticker?: unknown }).sendSticker).toBeUndefined();
+  });
+});

--- a/test/features-handlers.test.ts
+++ b/test/features-handlers.test.ts
@@ -392,6 +392,24 @@ describe('handler registration and command matching', () => {
     expect(mockReply).toHaveBeenCalledWith(expect.anything(), expect.stringContaining('3-5 days'), { parse_mode: 'MarkdownV2' });
   });
 
+  it('runs a canned response through the chat handler when it replies to a ticket', async () => {
+    const handleText = jest.spyOn(text, 'handleText').mockResolvedValue(undefined);
+    const ctx = makeCtx({
+      match: ['/shipping', 'shipping'],
+      chat: { id: '-100123', type: 'supergroup' },
+    });
+    ctx.session.admin = true;
+    ctx.message.reply_to_message = { from: { is_bot: true }, text: '#T000001 from Alice', caption: '' } as never;
+
+    await commandHears()(ctx);
+
+    // the template replaces the command text and is delivered to the user, not echoed back
+    expect(ctx.message.text).toBe('3-5 days');
+    expect(handleText).toHaveBeenCalledWith(fakeAddon, ctx, []);
+    expect(mockReply).not.toHaveBeenCalled();
+    handleText.mockRestore();
+  });
+
   it('ignores unknown commands silently', async () => {
     await commandHears()(makeCtx({ match: ['/nothing', 'nothing'] }));
     expect(mockReply).not.toHaveBeenCalled();

--- a/test/match.test.ts
+++ b/test/match.test.ts
@@ -1,0 +1,44 @@
+// Tests for the ctx.match helpers shared by every addon (src/match.ts)
+import { matchArg, matchedCommand } from '../src/match';
+
+describe('matchArg', () => {
+  it('trims a plain command argument', () => {
+    expect(matchArg('  42 ')).toBe('42');
+    expect(matchArg('some longer text')).toBe('some longer text');
+  });
+
+  it('prefers the first capture group of a RegExp match', () => {
+    const match = '/faq'.match(/^\/(\w+)(?:@\w+)?$/);
+    expect(matchArg(match)).toBe('faq');
+  });
+
+  it('falls back to the whole match when there is no capture group', () => {
+    const match = '/faq'.match(/^\/\w+$/);
+    expect(matchArg(match)).toBe('/faq');
+  });
+
+  it('returns an empty string for missing or empty matches', () => {
+    expect(matchArg(undefined)).toBe('');
+    expect(matchArg(null)).toBe('');
+    expect(matchArg('')).toBe('');
+    expect(matchArg([] as unknown as RegExpMatchArray)).toBe('');
+  });
+});
+
+describe('matchedCommand', () => {
+  it('strips the leading slash', () => {
+    expect(matchedCommand('/faq')).toBe('faq');
+    expect(matchedCommand('faq')).toBe('faq');
+  });
+
+  it('handles RegExp match arrays as grammY hands them over', () => {
+    expect(matchedCommand('/hours'.match(/^\/(\w+)(?:@\w+)?$/))).toBe('hours');
+    expect(matchedCommand('/hours@my_bot'.match(/^\/(\w+)(?:@\w+)?$/))).toBe('hours');
+  });
+
+  it('returns null when nothing usable is left', () => {
+    expect(matchedCommand(undefined)).toBeNull();
+    expect(matchedCommand('/')).toBeNull();
+    expect(matchedCommand('')).toBeNull();
+  });
+});

--- a/test/middleware.test.ts
+++ b/test/middleware.test.ts
@@ -1,0 +1,64 @@
+// Tests for middleware.sendMessage routing: every addon must be reachable, otherwise
+// features like /broadcast (#159) silently skip whole platforms.
+const telegramSend = jest.fn().mockResolvedValue('1');
+const signalSend = jest.fn().mockResolvedValue('2');
+const slackSend = jest.fn().mockResolvedValue('3');
+const discordSend = jest.fn().mockResolvedValue('4');
+const emit = jest.fn();
+
+jest.mock('../src/addons/telegram', () => ({
+  __esModule: true,
+  default: { getInstance: () => ({ sendMessage: telegramSend }) },
+}));
+jest.mock('../src/addons/signal', () => ({
+  __esModule: true,
+  default: { getInstance: () => ({ sendMessage: signalSend }) },
+}));
+jest.mock('../src/addons/slack', () => ({
+  __esModule: true,
+  default: { getInstance: () => ({ sendMessage: slackSend }) },
+}));
+jest.mock('../src/addons/discord', () => ({
+  __esModule: true,
+  default: { getInstance: () => ({ sendMessage: discordSend }) },
+}));
+jest.mock('../src/cache', () => ({
+  __esModule: true,
+  default: {
+    config: { parse_mode: 'MarkdownV2', language: { replyPrivate: 'Reply' } },
+    io: { to: jest.fn(() => ({ emit })) },
+  },
+}));
+
+import * as middleware from '../src/middleware';
+import { Messenger } from '../src/interfaces';
+
+describe('sendMessage routing', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('reaches every messenger addon', async () => {
+    await middleware.sendMessage('1', Messenger.TELEGRAM, 'hi');
+    await middleware.sendMessage('2', Messenger.SIGNAL, 'hi');
+    await middleware.sendMessage('3', Messenger.SLACK, 'hi');
+    await middleware.sendMessage('4', Messenger.DISCORD, 'hi');
+
+    expect(telegramSend).toHaveBeenCalledWith('1', 'hi', { parse_mode: 'MarkdownV2' });
+    expect(signalSend).toHaveBeenCalledWith('2', 'hi', { parse_mode: 'MarkdownV2' });
+    expect(slackSend).toHaveBeenCalledWith('3', 'hi', { parse_mode: 'MarkdownV2' });
+    expect(discordSend).toHaveBeenCalledWith('4', 'hi', { parse_mode: 'MarkdownV2' });
+  });
+
+  it('emits web chat messages over the socket', async () => {
+    await expect(middleware.sendMessage('WEBabc', Messenger.WEB, 'hi')).resolves.toBeNull();
+    expect(emit).toHaveBeenCalledWith('chat_staff', 'hi');
+  });
+
+  it('collapses repeated spaces', async () => {
+    await middleware.sendMessage('1', Messenger.TELEGRAM, 'a    b');
+    expect(telegramSend).toHaveBeenCalledWith('1', 'a b', { parse_mode: 'MarkdownV2' });
+  });
+
+  it('throws for an unknown messenger', async () => {
+    await expect(middleware.sendMessage('1', 'matrix', 'hi')).rejects.toThrow('Invalid messenger type');
+  });
+});

--- a/test/signal-addon.test.ts
+++ b/test/signal-addon.test.ts
@@ -1,0 +1,145 @@
+// Tests for the Signal addon dispatch: command arguments (#85/#159) and the fall-through
+// to hears handlers that makes custom user commands (#84) and canned responses work.
+const axiosInstance = {
+  post: jest.fn().mockResolvedValue({ data: { timestamp: 1700000000 } }),
+  get: jest.fn().mockResolvedValue({ data: [] }),
+  put: jest.fn().mockResolvedValue({}),
+  delete: jest.fn().mockResolvedValue({}),
+};
+
+jest.mock('axios', () => ({ create: jest.fn(() => axiosInstance) }));
+jest.mock('ws', () => jest.fn().mockImplementation(() => ({ on: jest.fn() })));
+jest.mock('../src/handlers', () => ({ registerCommonHandlers: jest.fn() }));
+jest.mock('../src/cache', () => ({
+  __esModule: true,
+  default: { config: { signal_number: '+490000', signal_host: 'signal:8080' } },
+}));
+
+import SignalAddon from '../src/addons/signal';
+import { Context } from '../src/interfaces';
+import { SignalMessage } from '../src/addons/signal/models';
+
+const signalMessage = (message: string): SignalMessage =>
+  ({
+    account: '+490000',
+    envelope: {
+      source: '+491111',
+      sourceNumber: '+491111',
+      sourceUuid: 'uuid',
+      sourceName: 'Alice Example',
+      sourceDevice: 1,
+      timestamp: 1700000000,
+      serverReceivedTimestamp: 1700000000,
+      serverDeliveredTimestamp: 1700000000,
+      dataMessage: {
+        timestamp: 1700000000,
+        message,
+        expiresInSeconds: 0,
+        viewOnce: false,
+      },
+    },
+  } as SignalMessage);
+
+const deliver = async (addon: SignalAddon, message: string): Promise<void> => {
+  await (addon as unknown as { handleMessage: (data: string) => Promise<void> }).handleMessage(
+    JSON.stringify(signalMessage(message)),
+  );
+};
+
+describe('SignalAddon dispatch', () => {
+  const addon = SignalAddon.getInstance();
+  const handlers = (addon as unknown as { eventHandlers: Record<string, unknown[]> }).eventHandlers;
+  const hears = (addon as unknown as { hearsHandlers: unknown[] }).hearsHandlers;
+
+  // handleMessage schedules a 10s timer to hide the typing indicator
+  beforeAll(() => jest.useFakeTimers());
+  afterAll(() => jest.useRealTimers());
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    for (const key of Object.keys(handlers)) delete handlers[key];
+    hears.length = 0;
+  });
+
+  it('passes the text behind a command as ctx.match (#85, #159)', async () => {
+    const ticket = jest.fn();
+    addon.command('ticket', ticket);
+    await deliver(addon, '/ticket 1234');
+
+    expect(ticket).toHaveBeenCalledTimes(1);
+    expect((ticket.mock.calls[0][0] as Context).match).toBe('1234');
+  });
+
+  it('keeps multi-word arguments intact for /broadcast', async () => {
+    const broadcast = jest.fn();
+    addon.command('broadcast', broadcast);
+    await deliver(addon, '/broadcast we are back online');
+
+    expect((broadcast.mock.calls[0][0] as Context).match).toBe('we are back online');
+  });
+
+  it('leaves ctx.match empty for a command without arguments', async () => {
+    const open = jest.fn();
+    addon.command('open', open);
+    await deliver(addon, '/open');
+
+    expect((open.mock.calls[0][0] as Context).match).toBe('');
+  });
+
+  it('routes unknown slash commands to hears with the capture group (#84)', async () => {
+    const canned = jest.fn();
+    addon.hears(/^\/(\w+)(?:@\w+)?$/, canned);
+    await deliver(addon, '/faq');
+
+    expect(canned).toHaveBeenCalledTimes(1);
+    const ctx = canned.mock.calls[0][0] as Context;
+    expect(Array.isArray(ctx.match) ? ctx.match[1] : ctx.match).toBe('faq');
+  });
+
+  it('does not run hears handlers once a command handler took the message', async () => {
+    const close = jest.fn();
+    const canned = jest.fn();
+    addon.command('close', close);
+    addon.hears(/^\/(\w+)$/, canned);
+    await deliver(addon, '/close');
+
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(canned).not.toHaveBeenCalled();
+  });
+
+  it('runs only the first matching hears trigger', async () => {
+    const canned = jest.fn();
+    const catchAll = jest.fn();
+    addon.hears(/^\/(\w+)(?:@\w+)?$/, canned);
+    addon.hears(/(.+)/, catchAll);
+    await deliver(addon, '/faq');
+
+    expect(canned).toHaveBeenCalledTimes(1);
+    // otherwise the catch-all would open a ticket containing "/faq" on top of the answer
+    expect(catchAll).not.toHaveBeenCalled();
+  });
+
+  it('ignores updates without text, such as reactions', async () => {
+    const catchAll = jest.fn();
+    addon.hears(/(.+)/, catchAll);
+    const raw = JSON.parse(JSON.stringify(signalMessage('x')));
+    raw.envelope.dataMessage.message = null;
+    await (addon as unknown as { handleMessage: (data: string) => Promise<void> }).handleMessage(
+      JSON.stringify(raw),
+    );
+
+    expect(catchAll).not.toHaveBeenCalled();
+  });
+
+  it('still matches plain text triggers', async () => {
+    const back = jest.fn();
+    addon.hears('Back', back);
+    await deliver(addon, 'Back');
+
+    expect(back).toHaveBeenCalledTimes(1);
+  });
+
+  it('has no sticker support, so the sticker handler is never registered', () => {
+    expect((addon as { sendSticker?: unknown }).sendSticker).toBeUndefined();
+  });
+});

--- a/test/slack-addon.test.ts
+++ b/test/slack-addon.test.ts
@@ -1,0 +1,82 @@
+// Tests for the Slack addon dispatch: command arguments and RegExp matches handed to
+// handlers the same way grammY does, so the shared commands work on Slack too.
+const axiosInstance = {
+  post: jest.fn().mockResolvedValue({ data: { ok: true, ts: '1.2' } }),
+  get: jest.fn().mockResolvedValue({ data: { ok: true } }),
+};
+
+jest.mock('axios', () => ({ create: jest.fn(() => axiosInstance) }));
+jest.mock('../src/handlers', () => ({ registerCommonHandlers: jest.fn() }));
+jest.mock('../src/cache', () => ({
+  __esModule: true,
+  default: { config: { slack_bot_token: 'token', slack_channel_id: '', slack_enabled: true } },
+}));
+
+import SlackAddon from '../src/addons/slack';
+import { Context } from '../src/interfaces';
+
+const message = (text: string) => ({
+  type: 'message',
+  channel: 'C1',
+  user: 'U1',
+  ts: '1700000000.000100',
+  text,
+});
+
+describe('SlackAddon dispatch', () => {
+  const addon = SlackAddon.getInstance();
+  const commandHandlers = (addon as unknown as { commandHandlers: Map<string, unknown> }).commandHandlers;
+  const hears = (addon as unknown as { hearsHandlers: unknown[] }).hearsHandlers;
+  const deliver = (text: string) =>
+    (addon as unknown as { handleRTMMessage: (msg: unknown) => void }).handleRTMMessage(message(text));
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    commandHandlers.clear();
+    hears.length = 0;
+  });
+
+  it('passes the text behind a command as ctx.match', () => {
+    const broadcast = jest.fn();
+    addon.command('broadcast', broadcast);
+    deliver('/broadcast we are back online');
+
+    expect((broadcast.mock.calls[0][0] as Context).match).toBe('we are back online');
+  });
+
+  it('hands RegExp triggers the match array instead of a stringified one (#84)', () => {
+    const canned = jest.fn();
+    addon.hears(/^\/(\w+)(?:@\w+)?$/, canned);
+    deliver('/faq');
+
+    const match = (canned.mock.calls[0][0] as Context).match;
+    expect(Array.isArray(match)).toBe(true);
+    expect((match as RegExpMatchArray)[1]).toBe('faq');
+  });
+
+  it('prefers a registered command over the hears fall-through', () => {
+    const close = jest.fn();
+    const canned = jest.fn();
+    addon.command('close', close);
+    addon.hears(/^\/(\w+)$/, canned);
+    deliver('/close');
+
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(canned).not.toHaveBeenCalled();
+  });
+
+  it('ignores bot messages', () => {
+    const canned = jest.fn();
+    addon.hears(/^\/(\w+)$/, canned);
+    (addon as unknown as { handleRTMMessage: (msg: unknown) => void }).handleRTMMessage({
+      ...message('/faq'),
+      subtype: 'bot_message',
+    });
+
+    expect(canned).not.toHaveBeenCalled();
+  });
+
+  it('has no sticker support, so the sticker handler is never registered', () => {
+    expect((addon as { sendSticker?: unknown }).sendSticker).toBeUndefined();
+  });
+});


### PR DESCRIPTION
The features added for the open issues only worked on Telegram. Three addon
bugs kept them from reaching the other platforms:

- Signal never set ctx.match, so /ticket <id> and /broadcast <text> could not
  read their arguments and always answered with their usage line. It also
  treated any "/"-prefixed text as a command, so unknown slash commands never
  reached the hears handlers and user_commands and canned responses were dead.
  Unknown commands now fall through, only the first matching trigger runs (the
  catch-all would otherwise open a ticket on top of every canned answer) and
  updates without text no longer open a ticket containing "null".
- Slack and Discord passed the stringified RegExp match ("/faq,faq") to the
  handler, so the command key never resolved. They now hand over the match
  array like grammY does.
- The Messenger enum had no slack/discord members, so middleware.sendMessage
  threw "Invalid messenger type" for both — every reply on those platforms
  failed and /broadcast skipped their users.

ctx.match is now typed as string | RegExpMatchArray and read through the
matchArg/matchedCommand helpers in src/match.ts.

Two more fixes from reviewing the branch: a canned response sent as a reply to
a ticket was dropped silently, because a hears handler ends the middleware
chain and the chat handler it relied on never ran; and staffchat_thread_id was
compared strictly against message_thread_id, which locks staff out of their own
topic when the id is quoted in config.yaml.

Stickers, forum topics, reply keyboards and edit events stay Telegram-only —
the other platforms have no equivalent — and the README now says so.

Adds 47 tests: per-addon dispatch suites for Signal, Slack and Discord, a
parity suite that registers the common handlers for all four platforms, plus
coverage for the match helpers and messenger routing.

Rebased onto master after #190 and #203; the `staffchat_thread_id` comparison now combines the callback-query guard from #190 with the string comparison from this change.

Verified locally: tsc clean, 19 suites / 173 tests passing.